### PR TITLE
Performance improvements in tracking and CSR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,12 @@
 .vscode/
 *.log
 **.ipynb_checkpoints/
+.venv
+build/
+dist/
+ocelot.egg-info/
 .DS_Store
+arcline_traj.png
+arcline_traj_0.png
+dev_tests/5_CSR.py
+dev_tests/__init__.py

--- a/ocelot/cpbd/csr.py
+++ b/ocelot/cpbd/csr.py
@@ -476,12 +476,9 @@ class K0_fin_anf:
 
         # integrated kernel: KS=int_s^0{K(u)*du}=int_0^{-s}{K(-u)*du}
 
-        if len(K) > 1:
-            a = np.append(0.5 * (K[0:-1] + K[1:]) * np.diff(s), 0.5 * K[-1] * s[-1])
-            KS = np.cumsum(a[::-1])[::-1]
-            # KS = cumtrapz(K[::-1], -s[::-1], initial=0)[::-1] + 0.5*K[-1]*s[-1]
-        else:
-            KS = 0.5 * K[-1] * s[-1]
+        K[:-1] += K[1:]
+        K *= 0.5 * np.diff(s, append=0)
+        KS = np.cumsum(K[::-1])[::-1]
 
         return w, KS
 

--- a/ocelot/cpbd/csr.py
+++ b/ocelot/cpbd/csr.py
@@ -495,26 +495,32 @@ class K0_fin_anf:
         g2i = 1. / gamma ** 2
         b2 = 1. - g2i
         beta = np.sqrt(b2)
+
+        i_0 = self.estimate_start_index(i, traj, wmin, beta)
         
-        s = traj[0, :i] - traj[0, i]
-        n0 = traj[1, i] - traj[1, :i]
-        n1 = traj[2, i] - traj[2, :i]
-        n2 = traj[3, i] - traj[3, :i]
+        s = traj[0, i_0:i] - traj[0, i]
+        n0 = traj[1, i] - traj[1, i_0:i]
+        n1 = traj[2, i] - traj[2, i_0:i]
+        n2 = traj[3, i] - traj[3, i_0:i]
         R = ne.evaluate("sqrt(n0**2 + n1**2 + n2**2)")
 
         w = ne.evaluate('s + beta*R')
         j = np.where(w <= wmin)[0]
-
         if len(j) > 0:
             j = j[-1]
-            w = w[j:i]
-            s = s[j:i]
+            w = w[j:]
+            s = s[j:]
+            n0 = n0[j:]
+            n1 = n1[j:]
+            n2 = n2[j:]
+            R = R[j:]
+            j += i_0
         else:
-            j = 0
-        R = R[j:i]
-        n0 = n0[j:i] / R
-        n1 = n1[j:i] / R
-        n2 = n2[j:i] / R
+            j = i_0
+        R_inv = 1 / R
+        n0 *= R_inv
+        n1 *= R_inv
+        n2 *= R_inv
 
         # kernel
         t4 = traj[4, j:i]

--- a/ocelot/cpbd/csr.py
+++ b/ocelot/cpbd/csr.py
@@ -443,12 +443,11 @@ class K0_fin_anf:
         g2i = 1. / gamma ** 2
         b2 = 1. - g2i
         beta = np.sqrt(b2)
-        i1 = i - 1  # ignore points i1+1:i on linear path to observer
-        ind1 = i1 + 1
-        s = traj[0, 0:ind1] - traj[0, i]
-        n = np.array([traj[1, i] - traj[1, 0:ind1],
-                      traj[2, i] - traj[2, 0:ind1],
-                      traj[3, i] - traj[3, 0:ind1]])
+        
+        s = traj[0, 0:i] - traj[0, i]
+        n = np.array([traj[1, i] - traj[1, 0:i],
+                      traj[2, i] - traj[2, 0:i],
+                      traj[3, i] - traj[3, 0:i]])
         R = np.sqrt(np.sum(n ** 2, axis=0))
 
         w = s + beta * R
@@ -456,19 +455,19 @@ class K0_fin_anf:
 
         if len(j) > 0:
             j = j[-1]
-            w = w[j:ind1]
-            s = s[j:ind1]
+            w = w[j:i]
+            s = s[j:i]
         else:
             j = 0
-        R = R[j:ind1]
-        n0 = n[0, j:ind1] / R
-        n1 = n[1, j:ind1] / R
-        n2 = n[2, j:ind1] / R
+        R = R[j:i]
+        n0 = n[0, j:i] / R
+        n1 = n[1, j:i] / R
+        n2 = n[2, j:i] / R
 
         # kernel
-        t4 = traj[4, j:i1 + 1]
-        t5 = traj[5, j:i1 + 1]
-        t6 = traj[6, j:i1 + 1]
+        t4 = traj[4, j:i]
+        t5 = traj[5, j:i]
+        t6 = traj[6, j:i]
 
         x = n0 * t4 + n1 * t5 + n2 * t6
         K = ((beta * (x - n0 * traj[4, i] - n1 * traj[5, i] - n2 * traj[6, i]) -

--- a/ocelot/cpbd/csr.py
+++ b/ocelot/cpbd/csr.py
@@ -7,12 +7,13 @@ import copy
 import importlib
 import logging
 
+import numpy as np
 from scipy import interpolate
 from scipy.integrate import cumtrapz
 from scipy.ndimage.filters import gaussian_filter
 from scipy.optimize import curve_fit
 
-from ocelot.common.globals import *
+from ocelot.common.globals import pi, speed_of_light, m_e_eV, m_e_GeV
 from ocelot.common import math_op
 from ocelot.cpbd.beam import Particle, s_to_cur
 from ocelot.cpbd.high_order import arcline, rk_track_in_field

--- a/ocelot/cpbd/csr.py
+++ b/ocelot/cpbd/csr.py
@@ -430,11 +430,11 @@ class K0_fin_anf:
         g2i = 1. / gamma ** 2
         b2 = 1. - g2i
         beta = np.sqrt(b2)
-        
+
         s = traj[0, :i] - traj[0, i]
         n = traj[1:4, [i]] - traj[1:4, :i]
         t = traj[4:, :i]
-        R = np.sqrt(np.sum(n*n, axis=0))
+        R = np.sqrt((n*n).sum(axis=0))
         w = s + beta * R
 
         j = np.where(w <= wmin)[0]
@@ -447,16 +447,17 @@ class K0_fin_anf:
             R = R[j:]
 
         # kernel
-        n /= R
-        x = np.sum(n * t, axis=0)
-        K = ((beta * (x - np.sum(n * traj[4:, [i]], axis=0)) -
-              b2 * (1 - np.sum(t * traj[4:, [i]], axis=0)) -
+        n = n / R
+        x = (n * t).sum(axis=0)
+        y = traj[4:, [i]]
+        K = ((beta * (x - (n * y).sum(axis=0)) -
+              b2 * (1. - (t * y).sum(axis=0)) -
               g2i) / R -
              (1. - beta * x) / w * g2i)
 
         # integrated kernel: KS=int_s^0{K(u)*du}=int_0^{-s}{K(-u)*du}
         K[:-1] += K[1:]
-        K *= 0.5 * np.diff(s, append=0)
+        K = 0.5 * K * np.diff(s, append=0)
         KS = np.cumsum(K[::-1])[::-1]
 
         return w, KS

--- a/ocelot/cpbd/csr.py
+++ b/ocelot/cpbd/csr.py
@@ -725,7 +725,7 @@ class CSR(PhysProc):
         else:
             KS = interp1(w, KS, w_range)
         four_pi_eps0 = 1./(1e-7*speed_of_light**2)
-        K1 = np.diff(np.append(np.diff(np.append(KS, 0)), 0))/NdW[1]/four_pi_eps0
+        K1 = np.diff(np.diff(KS, append=0), append=0) / NdW[1] / four_pi_eps0
 
         return K1
 

--- a/ocelot/cpbd/csr.py
+++ b/ocelot/cpbd/csr.py
@@ -495,13 +495,11 @@ class K0_fin_anf:
         g2i = 1. / gamma ** 2
         b2 = 1. - g2i
         beta = np.sqrt(b2)
-        i1 = i - 1  # ignore points i1+1:i on linear path to observer
-        # ra = np.arange(0, i1+1)
-        ind1 = i1 + 1
-        s = traj[0, 0:ind1] - traj[0, i]
-        n0 = traj[1, i] - traj[1, 0:ind1]
-        n1 = traj[2, i] - traj[2, 0:ind1]
-        n2 = traj[3, i] - traj[3, 0:ind1]
+        
+        s = traj[0, :i] - traj[0, i]
+        n0 = traj[1, i] - traj[1, :i]
+        n1 = traj[2, i] - traj[2, :i]
+        n2 = traj[3, i] - traj[3, :i]
         R = ne.evaluate("sqrt(n0**2 + n1**2 + n2**2)")
 
         w = ne.evaluate('s + beta*R')
@@ -509,19 +507,19 @@ class K0_fin_anf:
 
         if len(j) > 0:
             j = j[-1]
-            w = w[j:ind1]
-            s = s[j:ind1]
+            w = w[j:i]
+            s = s[j:i]
         else:
             j = 0
-        R = R[j:ind1]
-        n0 = n0[j:ind1] / R
-        n1 = n1[j:ind1] / R
-        n2 = n2[j:ind1] / R
+        R = R[j:i]
+        n0 = n0[j:i] / R
+        n1 = n1[j:i] / R
+        n2 = n2[j:i] / R
 
         # kernel
-        t4 = traj[4, j:i1 + 1]
-        t5 = traj[5, j:i1 + 1]
-        t6 = traj[6, j:i1 + 1]
+        t4 = traj[4, j:i]
+        t5 = traj[5, j:i]
+        t6 = traj[6, j:i]
 
         x = ne.evaluate('n0*t4 + n1*t5 + n2*t6')
 

--- a/ocelot/cpbd/csr.py
+++ b/ocelot/cpbd/csr.py
@@ -899,15 +899,13 @@ class CSR(PhysProc):
         gamma = p_array.E/m_e_GeV
         h = max(1., self.apply_step/self.traj_step)
 
+
         itr_ra = np.unique(-np.round(np.arange(-indx, -indx_prev, h))).astype(np.int)
 
-        nit = 0
-        n_iter = len(itr_ra)
-        #start = time.time()
-        K1 = self.CSR_K1(itr_ra[nit], self.csr_traj, Ndw, gamma)
-        for nit in range(1, n_iter):
-            K1 += self.CSR_K1(itr_ra[nit], self.csr_traj, Ndw, gamma=gamma)
-        K1 = K1/n_iter
+        K1 = 0
+        for it in itr_ra:
+            K1 += self.CSR_K1(it, self.csr_traj, Ndw, gamma=gamma)
+        K1 /= len(itr_ra)
 
 
         lam_K1 = csr_convolution(lam_ds, K1[::-1]) / st * delta_s

--- a/ocelot/cpbd/csr.py
+++ b/ocelot/cpbd/csr.py
@@ -430,11 +430,12 @@ class K0_fin_anf:
         g2i = 1. / gamma ** 2
         b2 = 1. - g2i
         beta = np.sqrt(b2)
-
+        
         s = traj[0, :i] - traj[0, i]
-        n = traj[1:4, [i]] - traj[1:4, :i]
-        t = traj[4:, :i]
-        R = np.sqrt((n*n).sum(axis=0))
+        n0 = traj[1, i] - traj[1, :i]
+        n1 = traj[2, i] - traj[2, :i]
+        n2 = traj[3, i] - traj[3, :i]
+        R = np.sqrt(n0*n0 + n1*n1 + n2*n2)
         w = s + beta * R
 
         j = np.where(w <= wmin)[0]
@@ -442,16 +443,29 @@ class K0_fin_anf:
             j = j[-1]
             w = w[j:i]
             s = s[j:i]
-            n = n[:, j:]
-            t = t[:, j:]
-            R = R[j:]
+            n0 = n0[j:i]
+            n1 = n1[j:i]
+            n2 = n2[j:i]
+            R = R[j:i]
+        else:
+            j = 0
+
+        n0 /= R
+        n1 /= R
+        n2 /= R
 
         # kernel
-        n = n / R
-        x = (n * t).sum(axis=0)
-        y = traj[4:, [i]]
-        K = ((beta * (x - (n * y).sum(axis=0)) -
-              b2 * (1. - (t * y).sum(axis=0)) -
+        t4 = traj[4, j:i]
+        t5 = traj[5, j:i]
+        t6 = traj[6, j:i]
+
+        t4_i = traj[4, i]
+        t5_i = traj[5, i]
+        t6_i = traj[6, i]
+
+        x = n0 * t4 + n1 * t5 + n2 * t6
+        K = ((beta * (x - n0 * t4_i - n1 * t5_i - n2 * t6_i) -
+              b2 * (1. - t4 * t4_i - t5 * t5_i - t6 * t6_i) -
               g2i) / R -
              (1. - beta * x) / w * g2i)
 

--- a/ocelot/cpbd/csr.py
+++ b/ocelot/cpbd/csr.py
@@ -277,7 +277,6 @@ class SubBinning:
             NBIN[ib] = NBIN[ib] + 1
         return NBIN
 
-
     def subbin_bound(self, q, s, x_qbin, n_bin, m_bin):
         """
         input
@@ -597,6 +596,7 @@ class K0_fin_anf:
                 i_0 = idx[j[-1]]
         return i_0
 
+
 class CSR(PhysProc):
     """
     coherent synchrotron radiation
@@ -645,7 +645,6 @@ class CSR(PhysProc):
         self.sub_bin = SubBinning(x_qbin=self.x_qbin, n_bin=self.n_bin, m_bin=self.m_bin)
         self.bin_smoth = Smoothing()
         self.k0_fin_anf = K0_fin_anf()
-
 
     def K0_inf_anf(self, i, traj, wmin):
         # function [ w,KS ] = K0_inf_anf( i,traj,wmin )
@@ -744,7 +743,6 @@ class CSR(PhysProc):
         else:
             KS = np.zeros(len(w_range))
         return KS
-
 
     def CSR_K1(self, i, traj, NdW, gamma=None):
         """
@@ -996,7 +994,6 @@ class CSR(PhysProc):
         # if self.pict_debug:
         #     data = np.array([ np.array(self.total_wake)])
         #     np.savetxt("total_wake_test.txt", data)
-
 
     def plot_wake(self, p_array, lam_K1, itr_ra, s1, st):
         """

--- a/ocelot/cpbd/csr.py
+++ b/ocelot/cpbd/csr.py
@@ -77,19 +77,6 @@ def interp1(x, y, xnew, k=1):
     return ynew
 
 
-def convolution(xu, u, xw, w):
-    """
-    convolution of equally spaced functions
-    """
-    hx = xu[1] - xu[0]
-    wc = np.convolve(u, w)*hx
-    nw = w.shape[0]
-    nu = u.shape[0]
-    x0 = xu[0] + xw[0]
-    xc = x0 + np.arange(nw + nu)*hx
-    return xc, wc
-
-
 def sample_0(i, a, b):
     y = max(0, min(i + 0.5, b) - max(i - 0.5, a))
     return y
@@ -980,57 +967,4 @@ class CSR(PhysProc):
         name = "0" * (4 - len(dig)) + dig
         self.plt.savefig( name + '.png')
 
-
-
-    def apply_i(self, p_array, delta_s):
-
-        s_cur = self.z0 - self.z_csr_start
-        z = p_array.tau()
-        s1 = min(z)
-        s2 = max(z)
-        bunch_size = s2 - s1
-        st = bunch_size / (self.n_mesh + 1)
-        I = s2current(z, p_array.q_array, n_points=self.n_mesh, filter_order=self.filter_order, mean_vel=speed_of_light)
-        Ns = len(I[:, 0])
-        sa = s1 + st / 2.
-        Ndw = [self.n_mesh, st]
-        lam_ds = I[:, 1] / speed_of_light * st
-
-        s_array = self.csr_traj[0, :]
-        indx = (np.abs(s_array - s_cur)).argmin()
-        indx_prev = (np.abs(s_array - (s_cur - delta_s))).argmin()
-        gamma = p_array.E / m_e_GeV
-        h = max(1., self.apply_step / self.traj_step)
-        itr_ra = np.unique(-np.round(np.arange(-indx, -indx_prev, h))).astype(np.int)
-
-        nit = 0
-        n_iter = len(itr_ra)
-        K1 = self.CSR_K1(itr_ra[nit], self.csr_traj, Ndw, gamma)
-        for nit in range(1, n_iter):
-            K1 += self.CSR_K1(itr_ra[nit], self.csr_traj, Ndw, gamma=gamma)
-        K1 = K1 / n_iter
-
-
-        lam_K1 = csr_convolution(lam_ds, K1) / st * delta_s
-        Nend = len(lam_K1)
-        N = int(abs(self.n_mesh + 1 - Nend) + self.n_mesh + 1)
-        x = np.linspace(I[-1, 0], I[-1, 0] - N * Ndw[1], num=N, endpoint=False)[::-1]
-        tck = interpolate.splrep(x, lam_K1, k=1)
-        dE = interpolate.splev(z, tck, der=0)
-        pc_ref = np.sqrt(p_array.E ** 2 / m_e_GeV ** 2 - 1) * m_e_GeV
-        delta_p = dE * 1e-9 / pc_ref
-        p_array.rparticles[5] += delta_p
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+        

--- a/ocelot/cpbd/csr.py
+++ b/ocelot/cpbd/csr.py
@@ -234,7 +234,8 @@ class Smoothing:
                     charge_per_step[k-1] += w * qps
 
         elif IP_method == 2:
-            charge_per_step = self.q_per_step_ip2(N_BIN, Q_BIN, BIN[0], BIN[1], NSIG, RMS, step, Nz, z1)
+            charge_per_step = self.q_per_step_ip2(
+                N_BIN, Q_BIN, BIN[0], BIN[1], NSIG, RMS, step, Nz, z1)
         else:
             for nb in range(N_BIN):
                 aa = BIN[0][nb] - z1
@@ -258,7 +259,9 @@ class SubBinning:
         self.print_log = False
         if nb_flag:
             logger.debug("SubBinning: NUMBA")
-            self.p_per_subbins = nb.jit(nb.double[:](nb.double[:], nb.double[:], nb.int64))(self.p_per_subbins_py)
+            self.p_per_subbins = nb.jit(
+                nb.double[:](nb.double[:], nb.double[:], nb.int64))(
+                    self.p_per_subbins_py)
         else:
             logger.debug("SubBinning: Python")
             self.p_per_subbins = self.p_per_subbins_py
@@ -318,7 +321,9 @@ class SubBinning:
             # bb=monoton "length" vector
             # bb = ne.evaluate('(s - s0) / (sNs - s0)')
             # aa=LK of "charge" and "length" vector; avoid zero stepwidth
-            aa = ne.evaluate('(aa - aa0) / (aaNs - aa0) * X_QBIN + (s - s0) / (sNs - s0) * (1 - X_QBIN)')
+            aa = ne.evaluate(
+                '(aa - aa0) / (aaNs - aa0) * X_QBIN +'
+                '(s - s0) / (sNs - s0) * (1 - X_QBIN)')
         else:
             aa = (aa - aa[0]) / (aa[Ns - 1] - aa[0])
             # bb=monoton "length" vector
@@ -368,9 +373,12 @@ class K0_fin_anf:
             t5 = traj5[i]
             t6 = traj6[i]
             x = n0i * t4 + n1i * t5 + n2i * t6
-            K[i - j] = ((beta * (x - n0i * traj4[indx] - n1i * traj5[indx] - n2i * traj6[indx]) -
-                         b2 * (1. - t4 * traj4[indx] - t5 * traj5[indx] - t6 * traj6[indx]) - g2i) / Ri - (
-                        1. - beta * x) / w[i - j] * g2i)
+            K[i - j] = ((beta * (x - n0i * traj4[indx] -
+                                 n1i * traj5[indx] - n2i * traj6[indx]) -
+                         b2 * (1. - t4 * traj4[indx] - t5 * traj5[indx] -
+                               t6 * traj6[indx]) -
+                         g2i) / Ri -
+                        (1. - beta * x) / w[i - j] * g2i)
         return K
 
     def K0_0_jit(self, i, traj0, traj1, traj2, traj3, gamma, s, n, R, w):
@@ -492,7 +500,9 @@ class K0_fin_anf:
         t5i = traj[5, i]
         t6i = traj[6, i]
         K = ne.evaluate(
-            '((beta*(x - n0*t4i- n1*t5i - n2*t6i) - b2*(1. - t4*t4i - t5*t5i - t6*t6i) - g2i)/R - (1. - beta*x)/w*g2i)')
+            '((beta*(x - n0*t4i- n1*t5i - n2*t6i) -'
+            '  b2*(1. - t4*t4i - t5*t5i - t6*t6i) - g2i)/R -'
+            ' (1. - beta*x)/w*g2i)')
 
         K[:-1] += K[1:]
         K *= 0.5 * np.diff(s, append=0)
@@ -576,7 +586,9 @@ class CSR(PhysProc):
         K = (n[0, ra]*(traj[4, ra] - traj[4, i]) +
              n[1, ra]*(traj[5, ra] - traj[5, i]) +
              n[2, ra]*(traj[6, ra] - traj[6, i]) -
-           (1. - traj[4, ra]*traj[4, i] - traj[5, ra]*traj[5, i] - traj[6, ra]*traj[6, i]))/R[ra]
+             (1. - traj[4, ra]*traj[4, i] -
+              traj[5, ra]*traj[5, i] -
+              traj[6, ra]*traj[6, i])) / R[ra]
 
         # integrated kernel: KS=int_s^0{K(u)*du}=int_0^{-s}{K(-u)*du}
         if np.shape(K)[0] > 1:

--- a/ocelot/cpbd/csr.py
+++ b/ocelot/cpbd/csr.py
@@ -65,18 +65,6 @@ def csr_convolution(a, b):
     return c
 
 
-def interp1(x, y, xnew, k=1):
-    if len(xnew) > 0:
-        if k == 1:
-            ynew = np.interp(xnew, x, y)
-        else:
-            tck = interpolate.splrep(x, y, k=k)
-            ynew = interpolate.splev(xnew, tck, der=0)
-    else:
-        ynew = []
-    return ynew
-
-
 def sample_0(i, a, b):
     y = max(0, min(i + 0.5, b) - max(i - 0.5, a))
     return y
@@ -334,7 +322,7 @@ class SubBinning:
             aa = 0.999 * aa + 0.001 * (np.arange(0, Ns)) / (Ns - 1)
 
         # vector with bin boundaries
-        SBINB = interp1(aa, s, np.arange(K_BIN + 1.) / K_BIN)
+        SBINB = np.interp(np.arange(K_BIN + 1.) / K_BIN, aa, s)
         SBINB[0] = s[0]
         SBINB[K_BIN] = s[Ns - 1]
         # particles per subbins
@@ -709,10 +697,10 @@ class CSR(PhysProc):
                 KS2 = self.K0_inf_inf(i, traj, np.append(w_range[0:m+1], w_min))
 
             KS2 = (KS2[-1] - KS2) + KS1
-            KS = np.append(KS2[0:-1], interp1(w, KS, w_range[m+1:]))
+            KS = np.append(KS2[0:-1], np.interp(w_range[m+1:], w, KS))
 
         else:
-            KS = interp1(w, KS, w_range)
+            KS = np.interp(w_range, w, KS)
         four_pi_eps0 = 1./(1e-7*speed_of_light**2)
         K1 = np.diff(np.diff(KS, append=0), append=0) / NdW[1] / four_pi_eps0
 

--- a/ocelot/cpbd/csr.py
+++ b/ocelot/cpbd/csr.py
@@ -2,36 +2,42 @@
 @ authors Martin Dohlus DESY, 2015, Sergey Tomin XFEL, 2016
 """
 
+import time
+import copy
+import importlib
+import logging
+
 from scipy import interpolate
-from ocelot.common.globals import *
-from ocelot.common import math_op
+from scipy.integrate import cumtrapz
 from scipy.ndimage.filters import gaussian_filter
 from scipy.optimize import curve_fit
-from ocelot.cpbd.beam import *
-from ocelot.cpbd.high_order import *
-from ocelot.cpbd.magnetic_lattice import *
-import time
-from scipy.integrate import cumtrapz
-from ocelot.cpbd.physics_proc import PhysProc
-import copy
-from ocelot.rad.radiation_py import und_field
-import importlib
 
-import logging
+from ocelot.common.globals import *
+from ocelot.common import math_op
+from ocelot.cpbd.beam import Particle, s_to_cur
+from ocelot.cpbd.high_order import arcline, rk_track_in_field
+from ocelot.cpbd.magnetic_lattice import (Undulator, Bend, RBend, SBend,
+                                          XYQuadrupole)
+from ocelot.cpbd.physics_proc import PhysProc
+from ocelot.rad.radiation_py import und_field
+
+# Try to import numba, pyfftw and numexpr for improved performance
 logger = logging.getLogger(__name__)
 
 try:
     import numba as nb
     nb_flag = True
 except:
-    logger.info("csr.py: module NUMBA is not installed. Install it to speed up calculation")
+    logger.info("csr.py: module NUMBA is not installed."
+                " Install it to speed up calculation")
     nb_flag = False
 
 try:
     from pyfftw.interfaces.numpy_fft import fft
     from pyfftw.interfaces.numpy_fft import ifft
 except:
-    logger.info("csr.py: module PYFFTW is not installed. Install it to speed up calculation.")
+    logger.info("csr.py: module PYFFTW is not installed."
+                " Install it to speed up calculation.")
     from numpy.fft import ifft
     from numpy.fft import fft
 
@@ -39,7 +45,8 @@ try:
     import numexpr as ne
     ne_flag = True
 except:
-    logger.info("csr.py: module NUMEXPR is not installed. Install it to speed up calculation")
+    logger.info("csr.py: module NUMEXPR is not installed."
+                " Install it to speed up calculation")
     ne_flag = False
 
 

--- a/ocelot/cpbd/csr.py
+++ b/ocelot/cpbd/csr.py
@@ -695,16 +695,18 @@ class CSR(PhysProc):
 
         KS1 = KS[0]
 
-        w, idx = np.unique(w, return_index=True)
-        KS = KS[idx]
-
+        # w, idx = np.unique(w, return_index=True)
+        # KS = KS[idx]
         # sort and unique takes time, but is required to avoid numerical trouble
-        if w_range[0] < w[0]:
-            m = np.where(w_range < w[0])[0][-1]
+
+        # Use w_min instead of unique and w[0]
+        w_min = np.min(w)
+        if w_range[0] < w_min:
+            m = np.where(w_range < w_min)[0][-1]
             if L_fin:
-                KS2 = self.K0_fin_inf(i, traj, np.append(w_range[0:m+1], w[0]), gamma)
+                KS2 = self.K0_fin_inf(i, traj, np.append(w_range[0:m+1], w_min), gamma)
             else:
-                KS2 = self.K0_inf_inf(i, traj, np.append(w_range[0:m+1], w[0]))
+                KS2 = self.K0_inf_inf(i, traj, np.append(w_range[0:m+1], w_min))
 
             KS2 = (KS2[-1] - KS2) + KS1
             KS = np.append(KS2[0:-1], interp1(w, KS, w_range[m+1:]))

--- a/ocelot/cpbd/optics.py
+++ b/ocelot/cpbd/optics.py
@@ -31,11 +31,20 @@ except ImportError as error:
 
 class SecondOrderMult:
     """
-    The class includes three different methods transforming the particles coordinates:
-    1. based on NUMEXPR module - gives the better performance
-    2. NUMBA module (switched off) - slowest method (around 2-3 times slower) but used full matrix for transformation
-                        (in the future can be more preferable for usage)
-    3. NUMPY module - gives a bit slower performance then NUMEXPR and identical to the first one on the algorithm level.
+    The class includes three different methods for transforming the particle
+    coordinates:
+
+    1. NUMEXPR module
+        Fastest methos, but does not use full matrix multiplication.
+
+    2. NUMBA module
+        Slightly faster than NUMPY for simulations with a large number of time
+        steps. Uses full matrix multiplication.
+
+    3. NUMPY module
+        Base method to be used if neither NUMBA not NUMEXPR are installed.
+        Uses full matrix multiplication.
+
     """
     def __init__(self):
         self.full_matrix = False

--- a/ocelot/cpbd/optics.py
+++ b/ocelot/cpbd/optics.py
@@ -98,7 +98,7 @@ class SecondOrderMult:
         X[4] = X_4
 
     def numpy_apply(self, X, R, T):
-        X[:] = np.matmul(R, X) + np.einsum('ijk,j...,k...', T, X, X).T
+        X[:] = np.matmul(R, X) + np.einsum('ijk,j...,k...->i...', T, X, X)
 
 
 def transform_vec_ent(X, dx, dy, tilt):

--- a/ocelot/cpbd/optics.py
+++ b/ocelot/cpbd/optics.py
@@ -84,38 +84,7 @@ class SecondOrderMult:
         X[4] = ne.evaluate('R40 * x + R41 * px + R42 * y + R43 * py + R44 * tau + R45 * dp + T400 * x*x + T401 * x*px + T405 * x*dp + T411 * px*px + T415 * px*dp + T455 * dp*dp + T422 * y*y + T423 * y*py + T433 * py*py')  # + U5666*dp2*dp    # third order
 
     def numpy_apply(self, X, R, T):
-        Xr = np.dot(R, X)
-        x, px, y, py, tau, dp = X[0], X[1], X[2], X[3], X[4], X[5]
-        x2 = x * x
-        xpx = x * px
-        px2 = px * px
-        py2 = py * py
-        ypy = y * py
-        y2 = y * y
-        dp2 = dp * dp
-        xdp = x * dp
-        pxdp = px * dp
-        xy = x * y
-        xpy = x * py
-        ypx = px * y
-        pxpy = px * py
-        ydp = y * dp
-        pydp = py * dp
-
-        X[0] = Xr[0] + T[0, 0, 0] * x2 + T[0, 0, 1] * xpx + T[0, 0, 5] * xdp + T[0, 1, 1] * px2 + T[0, 1, 5] * pxdp + \
-                  T[0, 5, 5] * dp2 + T[0, 2, 2] * y2 + T[0, 2, 3] * ypy + T[0, 3, 3] * py2
-
-        X[1] = Xr[1] + T[1, 0, 0] * x2 + T[1, 0, 1] * xpx + T[1, 0, 5] * xdp + T[1, 1, 1] * px2 + T[1, 1, 5] * pxdp + \
-                  T[1, 5, 5] * dp2 + T[1, 2, 2] * y2 + T[1, 2, 3] * ypy + T[1, 3, 3] * py2
-
-        X[2] = Xr[2] + T[2, 0, 2] * xy + T[2, 0, 3] * xpy + T[2, 1, 2] * ypx + T[2, 1, 3] * pxpy + T[ 2, 2, 5] * ydp + \
-                  T[2, 3, 5] * pydp
-
-        X[3] = Xr[3] + T[3, 0, 2] * xy + T[3, 0, 3] * xpy + T[3, 1, 2] * ypx + T[3, 1, 3] * pxpy + T[3, 2, 5] * ydp + \
-                  T[3, 3, 5] * pydp
-
-        X[4] = Xr[4] + T[4, 0, 0] * x2 + T[4, 0, 1] * xpx + T[4, 0, 5] * xdp + T[4, 1, 1] * px2 + T[4, 1, 5] * pxdp + \
-                  T[4, 5, 5] * dp2 + T[4, 2, 2] * y2 + T[4, 2, 3] * ypy + T[4, 3, 3] * py2  # + U5666*dp2*dp    # third order
+        X[:] = np.dot(R, X) + np.einsum('ijk,j...,k...', T, X, X).T
 
 
 def transform_vec_ent(X, dx, dy, tilt):

--- a/ocelot/cpbd/optics.py
+++ b/ocelot/cpbd/optics.py
@@ -98,7 +98,7 @@ class SecondOrderMult:
         X[4] = X_4
 
     def numpy_apply(self, X, R, T):
-        X[:] = np.dot(R, X) + np.einsum('ijk,j...,k...', T, X, X).T
+        X[:] = np.matmul(R, X) + np.einsum('ijk,j...,k...', T, X, X).T
 
 
 def transform_vec_ent(X, dx, dy, tilt):

--- a/ocelot/cpbd/optics.py
+++ b/ocelot/cpbd/optics.py
@@ -51,16 +51,14 @@ class SecondOrderMult:
 
     def numba_apply(self, X, R, T):
         Xcopy = np.copy(X)
-        N = X.shape[1]
-        for i in range(6):
-            for n in range(N):
-                tmp = 0.
-                r_tmp = 0.
+        for n in range(X.shape[1]):
+            for i in range(6):
+                x_new = 0
                 for j in range(6):
-                    r_tmp += R[i, j]*Xcopy[j, n]
+                    x_new += R[i, j]*Xcopy[j, n]
                     for k in range(6):
-                        tmp += T[i, j, k] * Xcopy[j, n] * Xcopy[k, n]
-                X[i, n] = r_tmp + tmp
+                        x_new += T[i, j, k] * Xcopy[j, n] * Xcopy[k, n]
+                X[i, n] = x_new
 
     def numexpr_apply(self, X, R, T):
         x, px, y, py, tau, dp = X

--- a/ocelot/cpbd/optics.py
+++ b/ocelot/cpbd/optics.py
@@ -39,10 +39,10 @@ class SecondOrderMult:
     """
     def __init__(self):
         self.full_matrix = False
-        if ne_flag:
+        if ne_flag and not self.full_matrix:
             # print("SecondTM: NumExpr")
             self.tmat_multip = self.numexpr_apply
-        elif nb_flag and self.full_matrix:
+        elif nb_flag:
             # print("SecondTM: NUMBA")
             self.tmat_multip = nb.jit(nopython=True, parallel=True)(self.numba_apply)
         else:

--- a/ocelot/cpbd/optics.py
+++ b/ocelot/cpbd/optics.py
@@ -63,13 +63,14 @@ class SecondOrderMult:
                 X[i, n] = r_tmp + tmp
 
     def numexpr_apply(self, X, R, T):
-        x, px, y, py, tau, dp = np.copy((X[0], X[1], X[2], X[3], X[4], X[5]))
-        R00, R01, R02, R03, R04, R05 = R[0, 0], R[0, 1], R[0, 2], R[0, 3], R[0, 4], R[0, 5]
-        R10, R11, R12, R13, R14, R15 = R[1, 0], R[1, 1], R[1, 2], R[1, 3], R[1, 4], R[1, 5]
-        R20, R21, R22, R23, R24, R25 = R[2, 0], R[2, 1], R[2, 2], R[2, 3], R[2, 4], R[2, 5]
-        R30, R31, R32, R33, R34, R35 = R[3, 0], R[3, 1], R[3, 2], R[3, 3], R[3, 4], R[3, 5]
-        R40, R41, R42, R43, R44, R45 = R[4, 0], R[4, 1], R[4, 2], R[4, 3], R[4, 4], R[4, 5]
-        R50, R51, R52, R53, R54, R55 = R[5, 0], R[5, 1], R[5, 2], R[5, 3], R[5, 4], R[5, 5]
+        x, px, y, py, tau, dp = X
+        
+        R00, R01, R02, R03, R04, R05 = R[0]
+        R10, R11, R12, R13, R14, R15 = R[1]
+        R20, R21, R22, R23, R24, R25 = R[2]
+        R30, R31, R32, R33, R34, R35 = R[3]
+        R40, R41, R42, R43, R44, R45 = R[4]
+        R50, R51, R52, R53, R54, R55 = R[5]
 
         T000, T001, T005, T011, T015, T055, T022, T023, T033 = T[0, 0, 0], T[0, 0, 1], T[0, 0, 5], T[0, 1, 1], T[0, 1, 5], T[0, 5, 5], T[0, 2, 2],T[0, 2, 3], T[0, 3, 3]
         T100, T101, T105, T111, T115, T155, T122, T123, T133 = T[1, 0, 0], T[1, 0, 1], T[1, 0, 5], T[1, 1, 1], T[1, 1, 5], T[1, 5, 5], T[1, 2, 2],T[1, 2, 3], T[1, 3, 3]
@@ -77,11 +78,17 @@ class SecondOrderMult:
         T302, T303, T312, T313, T325, T335 = T[3, 0, 2],  T[3, 0, 3],  T[3, 1, 2],  T[3, 1, 3], T[3, 2, 5], T[3, 3, 5]
         T400, T401, T405, T411, T415, T455, T422, T423, T433 = T[4, 0, 0], T[4, 0, 1], T[4, 0, 5], T[4, 1, 1], T[4, 1, 5], T[4, 5, 5], T[4, 2, 2], T[4, 2, 3], T[4, 3, 3]
 
-        X[0] = ne.evaluate('R00 * x + R01 * px + R02 * y + R03 * py + R04 * tau + R05 * dp + T000 * x*x + T001 * x*px + T005 * x*dp + T011 * px*px + T015 * px*dp + T055 * dp*dp + T022 * y*y + T023 * y*py + T033 * py*py')
-        X[1] = ne.evaluate('R10 * x + R11 * px + R12 * y + R13 * py + R14 * tau + R15 * dp + T100 * x*x + T101 * x*px + T105 * x*dp + T111 * px*px + T115 * px*dp + T155 * dp*dp + T122 * y*y + T123 * y*py + T133 * py*py')
-        X[2] = ne.evaluate('R20 * x + R21 * px + R22 * y + R23 * py + R24 * tau + R25 * dp + T202 * x*y + T203 * x*py + T212 * y*px + T213 * px*py + T225 * y*dp + T235 * py*dp')
-        X[3] = ne.evaluate('R30 * x + R31 * px + R32 * y + R33 * py + R34 * tau + R35 * dp + T302 * x*y + T303 * x*py + T312 * y*px + T313 * px*py + T325 * y*dp + T335 * py*dp')
-        X[4] = ne.evaluate('R40 * x + R41 * px + R42 * y + R43 * py + R44 * tau + R45 * dp + T400 * x*x + T401 * x*px + T405 * x*dp + T411 * px*px + T415 * px*dp + T455 * dp*dp + T422 * y*y + T423 * y*py + T433 * py*py')  # + U5666*dp2*dp    # third order
+        X_0 = ne.evaluate('R00 * x + R01 * px + R02 * y + R03 * py + R04 * tau + R05 * dp + T000 * x*x + T001 * x*px + T005 * x*dp + T011 * px*px + T015 * px*dp + T055 * dp*dp + T022 * y*y + T023 * y*py + T033 * py*py')
+        X_1 = ne.evaluate('R10 * x + R11 * px + R12 * y + R13 * py + R14 * tau + R15 * dp + T100 * x*x + T101 * x*px + T105 * x*dp + T111 * px*px + T115 * px*dp + T155 * dp*dp + T122 * y*y + T123 * y*py + T133 * py*py')
+        X_2 = ne.evaluate('R20 * x + R21 * px + R22 * y + R23 * py + R24 * tau + R25 * dp + T202 * x*y + T203 * x*py + T212 * y*px + T213 * px*py + T225 * y*dp + T235 * py*dp')
+        X_3 = ne.evaluate('R30 * x + R31 * px + R32 * y + R33 * py + R34 * tau + R35 * dp + T302 * x*y + T303 * x*py + T312 * y*px + T313 * px*py + T325 * y*dp + T335 * py*dp')
+        X_4 = ne.evaluate('R40 * x + R41 * px + R42 * y + R43 * py + R44 * tau + R45 * dp + T400 * x*x + T401 * x*px + T405 * x*dp + T411 * px*px + T415 * px*dp + T455 * dp*dp + T422 * y*y + T423 * y*py + T433 * py*py')  # + U5666*dp2*dp    # third order
+        
+        X[0] = X_0
+        X[1] = X_1
+        X[2] = X_2
+        X[3] = X_3
+        X[4] = X_4
 
     def numpy_apply(self, X, R, T):
         X[:] = np.dot(R, X) + np.einsum('ijk,j...,k...', T, X, X).T

--- a/ocelot/cpbd/optics.py
+++ b/ocelot/cpbd/optics.py
@@ -44,7 +44,7 @@ class SecondOrderMult:
             self.tmat_multip = self.numexpr_apply
         elif nb_flag:
             # print("SecondTM: NUMBA")
-            self.tmat_multip = nb.jit(nopython=True, parallel=True)(self.numba_apply)
+            self.tmat_multip = nb.njit()(self.numba_apply)
         else:
             # print("SecondTM: Numpy")
             self.tmat_multip = self.numpy_apply


### PR DESCRIPTION
Hi everyone,

I have been working for some time on a few changes which can significantly speed-up particle tracking (with transfer maps) and the calculation of CSR effects. Many of these changes come directly from my own small tracking code [`Wake-T`](https://github.com/AngelFP/Wake-T) for plasma accelerators, in which the transfer maps and CSR are anyways based on the `Ocelot` implementation.

## Changes
The changes are only in the `optics.py` and `csr.py` files and can be summarized as follows:
* `optics.py` 
    * The `numpy_apply` method has been greatly simplified to a single line using 'np.einsum'. It now performs full matrix multiplication and is also ~20-30% faster than before.
    * The `numexpr_apply` method has also been modified in order not to require making a copy of the initial beam matrix and to simplify the creation of the beam arrays and Rij elements. As a result, this method is also ~20-30% faster than before.
    * The `numba_apply` method has only a few cosmetic changes and the `parallel=True` argument has been removed, since it didn't work anyways (at least in my tests).
    * In my tests, the `numba_apply` method was always slightly faster than `numpy_apply`, so I have changed the priority such that `numba_apply` is used if `numba` is installed.
    * Since now both `numpy_apply` and `numba_apply` have full matrix multiplication, I have also changed how the `self.full_matrix` parameter is used.

* `csr.py`:
    The changes with the biggest impact are those to the methods for computing `K0`. These are the following:
    * The implementation of `K0_fin_anf_np` is now significantly more efficient by changing the way in which some arrays are generated and computed. Redundant indices `i1` and `idx1` have been removed. Some of these changes have also been applied to `K0_fin_anf_numexpr` and `K0_fin_anf_opt`.
    * A new method `estimate_start_index` has been added which is used by `K0_fin_anf_np` and `K0_fin_anf_numexpr`. This method can significantly speed up the calculation of CSR effects by allowing to pre-discard some regions of the reference trajectory which do not contribute to the CSR kernel (see method documentation for more information).
    * The numba method `K0_0_jit` has also been modified to stop the loop once it detects that the trajectory points no longer contribute to the CSR kernel (i.e, once `w <= wmin`). This is more precise than the `estimate_start_index` method used by `numpy` and `numexpr`. Previously, the `n` and `R` arrays were computed for the whole trajectory, and only afterwards the parts where `w <= wmin` would be removed. This is now no longer necessary and only the required points are computed, leading to a potential speed-up of the calculation. The methods `K0_fin_anf_opt` and `K0_1_jit` have been adapted to take these changes into account.

    Other changes are:
    * I have removed the unused methods `convolution` and `apply_i`, as well as `interp1`, which has been replaced by `np.interp` because that's what it was always calling anyways.
    * I have changed a bit the imports to better organize them and avoid using `*`.
    * Simplified loop in `apply`.
    * Removed `w, idx = np.unique(w, return_index=True)` in `CSR_K1` because, if I understood it well, it might not be needed if `w[0]` is replaced by `np.min(w)` in the following lines. However, please correct this if I'm wrong.
    * Some formatting changes here and there.

## Benchmarks
To test the increase in performance and check that the physics is still correct, I have run the CSR example from the IPython tutorials. These were the results (units are in seconds):
| Using |  Before (no CSR)  |  After  (no CSR) |  Before (with CSR)  |  After  (with CSR)   |
|----|---|---|---|---|
|  `numpy`  |  2.6 | 2.0  | 170.3  |  99.6 |
|  `numpy` + `numba`   | 2.7  | 1.8  | 95.6  | 76.2  |
|  `numpy` + `numba` + `numexpr` | 0.7  | 0.5  |  92.7 | 70.9  |

While the values without CSR are usually quite consistent, the ones with CSR tend to fluctuate by up to ~10s from run to run. In any case, the results are always identical (at least to my eye), producing always:
![arcline_traj](https://user-images.githubusercontent.com/20479420/82228070-ef415800-9928-11ea-8828-23545083d67c.png)

Therefore, from these results and from how I understand the code, none of the changes have an impact on the physics. However, if you have other cases which can be simulated to validate the results, I would still recommend to test them.

I hope you find these changes useful, but feel free to suggest any modifications.
