### PR TITLE
Fix for PytestUnknownMarkWarning

### DIFF
--- a/unit_tests/pytest.ini
+++ b/unit_tests/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    update: mark a test as update.


### PR DESCRIPTION
pytest 6.0.1 throws a PytestUnknownMarkWarning because the marker "update" isn't described in pytest.ini.