### PR TITLE
add record of positon to number of lost particles to LostParticleRecorder

### DIFF
--- a/ocelot/cpbd/beam.py
+++ b/ocelot/cpbd/beam.py
@@ -600,15 +600,20 @@ class ParticleArray:
 
     class LostParticleRecorder:
         """
-        Stores all indices of particles that are getting lost.
-        Notes: The indices of the initial ParticleArray are used.
+        Stores information about particles that are getting lost.
+
+        Attributes:
+            lost_particles: List of indices of deleted particle. Notes: The indices of the initial ParticleArray are used.
+            lp_to_pos_hist: Histogram of number of lost particles to position s. [(pos, num of lost particles), ...]
         """
         def __init__(self, n):
             self.lost_particles = []
+            self.lp_to_pos_hist = []
             self._current_particle = np.arange(n)
 
-        def add(self, inds):
+        def add(self, inds, position):
             self.lost_particles += self._current_particle[inds].tolist()
+            self.lp_to_pos_hist.append((position, len(inds)))
             self._current_particle = np.delete(self._current_particle, inds)
 
     def __init__(self, n=0):
@@ -746,6 +751,7 @@ class ParticleArray:
         :param index:
         :return:
         """
+        _logger.warning("rm_particle is deprecated and will be removed in the future. Use delete_particles instead.")
         self.rparticles = np.delete(self.rparticles, index, 1)
         self.q_array = np.delete(self.q_array, index, 0)
 
@@ -782,8 +788,15 @@ class ParticleArray:
         val += "n particles : " + str(self.n) + "\n"
         return val
 
-    def delete_indices(self, inds):
-        self.lost_particle_recorder.add(inds)
+    def delete_particles(self, inds, record=True):
+        """
+        Deletes particles from the particle array via index.
+        :param inds: Indices that will be removed from the particle array.
+        :param record: If record is true the deleted particles will be saved in self.lost_particle_recorder.
+        :return:
+        """
+        if record:
+            self.lost_particle_recorder.add(inds, self.s)
         self.rparticles = np.delete(self.rparticles, inds, 1)
         self.q_array = np.delete(self.q_array, inds, 0)
 

--- a/ocelot/cpbd/physics_proc.py
+++ b/ocelot/cpbd/physics_proc.py
@@ -271,7 +271,7 @@ class PhaseSpaceAperture(PhysProc):
             sig = np.std(tau)
             inds = np.argwhere(np.logical_or(tau < sig * self.taumin, tau > sig * self.taumax))
             inds = inds.reshape(inds.shape[0])
-            p_array.delete_indices(inds)
+            p_array.delete_particles(inds)
 
         if self.horizontal:
             x = p_array.x()
@@ -280,7 +280,7 @@ class PhaseSpaceAperture(PhysProc):
             sigx = np.std(x)
             inds = np.argwhere(np.logical_or(x < sigx * self.xmin, x > sigx * self.xmax))
             inds = inds.reshape(inds.shape[0])
-            p_array.delete_indices(inds)
+            p_array.delete_particles(inds)
 
         if self.vertical:
             y = p_array.y()
@@ -289,7 +289,7 @@ class PhaseSpaceAperture(PhysProc):
             sigy = np.std(y)
             inds = np.argwhere(np.logical_or(y < sigy * self.ymin, y > sigy * self.ymax))
             inds = inds.reshape(inds.shape[0])
-            p_array.delete_indices(inds)
+            p_array.delete_particles(inds)
 
 
 class RectAperture(PhysProc):
@@ -317,12 +317,12 @@ class RectAperture(PhysProc):
         x = p_array.x()
         inds = np.argwhere(np.logical_or(x < self.xmin, x > self.xmax))
         inds = inds.reshape(inds.shape[0])
-        p_array.delete_indices(inds)
+        p_array.delete_particles(inds)
 
         y = p_array.y()
         inds = np.argwhere(np.logical_or(y < self.ymin, y > self.ymax))
         inds = inds.reshape(inds.shape[0])
-        p_array.delete_indices(inds)
+        p_array.delete_particles(inds)
 
 
 class BeamTransform(PhysProc):

--- a/unit_tests/utils_test/particle_array_test.py
+++ b/unit_tests/utils_test/particle_array_test.py
@@ -8,10 +8,13 @@ def test_lost_particle_recorder():
     p_array = np.arange(n)
     lpr = ParticleArray.LostParticleRecorder(n)
 
-    for inds in [[1, 3], [0, 1], [4, 10], [0, 1], [1, 0, 10, 7, 8]]:
-        lpr.add(inds)
+    for pos, inds in enumerate([[1, 3], [0, 1], [4, 10], [0, 1], [1, 0, 10, 7, 8]]):
+        lpr.add(inds, pos)
         p_array = np.delete(p_array, inds)
 
     lpr.lost_particles.sort()
     assert all([lp_idx == truth_idx for lp_idx, truth_idx in
                 zip(lpr.lost_particles, [0, 1, 2, 3, 4, 5, 6, 7, 8, 14, 15, 16, 18])])
+
+    assert all([lp_idx == truth_idx for lp_idx, truth_idx in
+                zip(lpr.lp_to_pos_hist, [(0, 2), (1, 2), (2, 2), (3, 2), (4, 5)])])


### PR DESCRIPTION
Add new attribute to LostParticleRecorder to record at which position s how many particles get lost.

Additionally the function "delete_indices" was renamed to "delete_particles" and  rm_particle() prints a warning that the function is deprecated. 