### PR TITLE
Update genesis.py

### DIFF
--- a/ocelot/adaptors/genesis.py
+++ b/ocelot/adaptors/genesis.py
@@ -1488,8 +1488,16 @@ def generate_input(undulator, beam, E_photon = None, itdp=True, *args, **kwargs)
     inp.emity = beam.emit_yn
     
     # idx_0 = inp.beam.I>0
-    rxbeam = np.nanmax(np.sqrt(inp.beam.beta_x * inp.beam.emit_x))
-    rybeam = np.nanmax(np.sqrt(inp.beam.beta_y * inp.beam.emit_y))
+    # if beam.len() !>1 the following will throw (cf line 1456 above):
+    try:
+        rxbeam = np.nanmax(np.sqrt(inp.beam.beta_x * inp.beam.emit_x))
+        rybeam = np.nanmax(np.sqrt(inp.beam.beta_y * inp.beam.emit_y))
+    except AttributeError:
+        rxbeam = np.nanmax(np.sqrt(beam.beta_x * beam.emit_xn))
+        rybeam = np.nanmax(np.sqrt(beam.beta_y * beam.emit_yn))
+    except:
+        raise
+      
     inp.dgrid = np.nanmax([rxbeam, rybeam]) * 8 #due to bug in Genesis2 that crashes when electrons leave the mesh
 
     inp.hn=1 # should be flexible in the future


### PR DESCRIPTION
Line 1456 tests for beam.len() > 1 and then assigns inp.beam. the case beam.len() !>1 is not treated which will then cause an exception in line 1491. This PR wraps lines 1496 in a try/except statement and tries to remedy the case beam.len() !> 1. No functionality nor regression tests were performed to justify this fix, so needs more testing and review.