### PR TITLE
CSR init with **kwarg + updated ipynb notebook (my first pull request)

### DIFF
--- a/demos/ipython_tutorials/5_CSR.ipynb
+++ b/demos/ipython_tutorials/5_CSR.ipynb
@@ -178,10 +178,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "csr = CSR()\n",
-    "csr.n_bin = 300\n",
-    "csr.m_bin = 5\n",
-    "csr.sigma_min = 0.2e-6"
+    "csr = CSR(n_bin=300, m_bin=5, sigma_min=.2e-6)"
    ]
   },
   {

--- a/ocelot/cpbd/csr.py
+++ b/ocelot/cpbd/csr.py
@@ -624,41 +624,43 @@ class CSR(PhysProc):
         self.traj_step = 0.0002 [m] - trajectory step or, other words, integration step for calculation of the CSR-wake
         self.apply_step = 0.0005 [m] - step of the calculation CSR kick, to calculate average CSR kick
     """
-    def __init__(self):
+    def __init__(self, **kw):
         PhysProc.__init__(self)
         # binning parameters
-        self.x_qbin = 0             # length or charge binning; 0... 1 = length...charge
-        self.n_bin = 100            # number of bins
-        self.m_bin = 5              # multiple binning(with shifted bins)
+        self.x_qbin = kw.get("x_qbin", 0) # length or charge binning; 0... 1 = length...charge
+        self.n_bin = kw.get("n_bin", 100) # number of bins
+        self.m_bin = kw.get("m_bin", 5)   # multiple binning(with shifted bins)
 
         # smoothing
-        self.ip_method = 2          # = 0 / 1 / 2 for rectangular / triangular / gauss
-        self.sp = 0.5               # ? parameter for gauss
-        self.sigma_min = 1.e-4      # minimal sigma, if ip_method == 2
-        self.step_unit = 0          # if positive --> step=integer * step_unit
+        self.ip_method = kw.get("ip_method", 2)     # = 0 / 1 / 2 for rectangular / triangular / gauss
+        self.sp = kw.get("sp", 0.5)                 # ? parameter for gauss
+        self.sigma_min = kw.get("sigma_min", 1.e-4) # minimal sigma, if ip_method == 2
+        self.step_unit = kw.get("step_unit", 0)     # if positive --> step=integer * step_unit
 
         # trajectory
-        self.traj_step = 0.0002     # [m] step of the trajectory
-        self.energy = None          # [GeV], if None, beta = 1 and calculation of the trajectory with RK is not possible
+        self.traj_step = kw.get("traj_step", 0.0002)  # [m] step of the trajectory
+        self.energy = kw.get("energy", None)          # [GeV], if None, beta = 1 and calculation of the trajectory with RK is not possible
 
         # CSR kick
-        self.apply_step = 0.0005    # [m] step of the calculation CSR kick: csr_kick += csr(apply_step)
-        self.step = 1               # step in the unit steps, step_in_[m] = self.step * navigator.unit_step [m].
-                                    # The CSR kick is applied at the end of the each step
+        self.apply_step = kw.get("apply_step", 0.0005) # [m] step of the calculation CSR kick: csr_kick += csr(apply_step)
+        self.step = kw.get("step", 1)                  # step in the unit steps, step_in_[m] = self.step * navigator.unit_step [m].
+                                                       # The CSR kick is applied at the end of the each step
 
-        self.z_csr_start = 0.       # z [m] position of the start_elem
-        self.z0 = 0.                # self.z0 = navigator.z0 in track.track()
+        self.z_csr_start = kw.get("z_csr_start", 0.) # z [m] position of the start_elem
+        self.z0 = kw.get("z0", 0.)                   # self.z0 = navigator.z0 in track.track()
 
-        self.end_poles = False      # if True magnetic field configuration 1/4, -3/4, 1, ...
-        self.rk_traj = False        # calculate trajectory of the reference particle with RK method
+        self.end_poles = kw.get("end_poles", False) # if True magnetic field configuration 1/4, -3/4, 1, ...
+        self.rk_traj = kw.get("rk_traj", False)     # calculate trajectory of the reference particle with RK method
 
-        self.debug = False
+        self.debug = kw.get("debug", False)
         # another filter
-        self.filter_order = 10
-        self.n_mesh = 345
+        self.filter_order = kw.get("filter_order", 10)
+        self.n_mesh = kw.get("n_mesh", 345)
 
-        self.pict_debug = False     # if True trajectory of the reference particle will be produced
-                                    # and CSR wakes will be saved in the working folder on each spep
+        # if True trajectory of the reference particle will be produced
+        # and CSR wakes will be saved in the working folder on each spep
+        self.pict_debug = kw.get("pict_debug", False)
+
 
         self.sub_bin = SubBinning(x_qbin=self.x_qbin, n_bin=self.n_bin, m_bin=self.m_bin)
         self.bin_smoth = Smoothing()


### PR DESCRIPTION
Something simple and easy for my first pull request.  Example:

```
x = X()
x.foo = 3
x.bar = "baz"
```

This is an anti-pattern.  Initialisation should go in the initialiser.  So I fixed this for the class CSR and also the jupyter notebook where it is used. 

change is backwards compatible / doesn't break api.