### PR TITLE
Improved get_envelope by adding exn/eyn and remove mutable kwarg.

### DIFF
--- a/ocelot/cpbd/beam.py
+++ b/ocelot/cpbd/beam.py
@@ -937,12 +937,12 @@ def recalculate_ref_particle(p_array):
     return p_array
 
 
-def get_envelope(p_array, tws_i=Twiss(), bounds=None):
+def get_envelope(p_array, tws_i=None, bounds=None):
     """
     Function to calculate twiss parameters form the ParticleArray
 
     :param p_array: ParticleArray
-    :param tws_i: optional, design Twiss,
+    :param tws_i: optional, design Twiss for dispersion correction.
     :param bounds: optional, [left_bound, right_bound] - bounds in units of std(p_array.tau())
     :return: Twiss()
     """
@@ -973,6 +973,9 @@ def get_envelope(p_array, tws_i=Twiss(), bounds=None):
     # if less than 3 particles are left in the ParticleArray - return default (zero) Twiss()
     if len(x) < 3:
         return tws
+
+    if tws_i is None:
+        tws_i = Twiss()
 
     dx = tws_i.Dx * p
     dy = tws_i.Dy * p
@@ -1044,6 +1047,10 @@ def get_envelope(p_array, tws_i=Twiss(), bounds=None):
 
     tws.emit_x = np.sqrt(tws.xx * tws.pxpx - tws.xpx ** 2)
     tws.emit_y = np.sqrt(tws.yy * tws.pypy - tws.ypy ** 2)
+    relgamma = p_array.E / m_e_GeV
+    relbeta = np.sqrt(1 - relgamma**-2)
+    tws.emit_xn = tws.emit_x * relgamma * relbeta
+    tws.emit_yn = tws.emit_y * relgamma * relbeta
 
     xx = tws.xx
     xpx = tws.xpx


### PR DESCRIPTION
add missing emit_xn and emit_yn attributes to the Twiss instance returned by get_envelope and also fixed Twiss as a default argument.  It's not a good idea to have mutable instances as kwargs in Python, instead one should use None and then maybe instantiate the class within the function body.