### PR TITLE
Better error when using CSR process incorrectly

### DIFF
--- a/ocelot/cpbd/high_order.py
+++ b/ocelot/cpbd/high_order.py
@@ -1524,7 +1524,12 @@ def arcline( SREin, Delta_S, dS, R_vect ):
             e1 = sre0[4:7]
             if np.abs(np.dot(n_vect, e1)) > epsilon:
                 R_vect_valid = False
-                print('*** error in arcline: invalid R_vect --> using Drift. Consider to use Runge-Kutta integrator')
+                msg = ("In arcline: invalid R_vect --> using Drift."
+                       " You may have attached the same CSR process to both horizontal"
+                       " and vertical bends.  Otherwise, consider using the Runge-Kutta"
+                       " integrator.")
+                _logger.error(msg)
+                print()
 
     if not R_vect_valid:
         SRE2[2-1, :] = sre0[2-1] + sre0[5-1]*np.arange(1, N+1)*dS


### PR DESCRIPTION
Better error when using CSR process incorrectly

I noticed this error in arcline happens when you attach the same CSR process to horizontal and vertical
bends.  So I tell the user that's maybe why.  And also a proper logger.error rather just
a call to print.  Maybe a better solution would be to make it work for both but I wouldn't know where to start with this code.