### PR TITLE
Options to return pd.DataFrame instead of list of Twiss instances

### DIFF
--- a/ocelot/cpbd/beam.py
+++ b/ocelot/cpbd/beam.py
@@ -7,11 +7,15 @@ from ocelot.common.globals import *
 from ocelot.common.math_op import find_nearest_idx
 from scipy.special import factorial
 from copy import deepcopy
+from typing import Iterable
 from scipy import interpolate
 from scipy.signal import savgol_filter
 from scipy.stats import truncnorm
 from ocelot.common.ocelog import *
 from ocelot.cpbd.reswake import pipe_wake
+
+import pandas as pd
+
 
 _logger = logging.getLogger(__name__)
 
@@ -202,6 +206,9 @@ class Twiss:
         val += "s        = " + str(self.s) + "\n"
         return val
 
+    def to_series(self) -> pd.Series:
+        """Return this Twiss instance as an equivalent Pandas Series instance."""
+        return pd.Series(vars(self))
 
 class Particle:
     """
@@ -2082,3 +2089,11 @@ def generate_beam(E, I=5000, l_beam=3e-6, **kwargs):
         beam_arr.add_chirp(kwargs['chirp'])
 
     return beam_arr
+
+def twiss_iterable_to_df(twisses: Iterable[Twiss]) -> pd.DataFrame:
+    """Convert an iterable of Twiss instances to a single DataFrame with the columns as
+    keys
+
+    :param twisses: iterable of twisses to be converted to a pandas DataFrame.
+    """
+    return pd.DataFrame(data=(t.to_series() for t in twisses))

--- a/ocelot/cpbd/optics.py
+++ b/ocelot/cpbd/optics.py
@@ -3,11 +3,12 @@ __author__ = 'Sergey'
 from copy import deepcopy
 from ocelot.cpbd.transformations.multipole import MultipoleTM
 from ocelot.cpbd.tm_params.second_order_params import SecondOrderParams
+import pandas as pd
 
 from numpy.linalg import inv
 
 from ocelot.cpbd.transformations.transfer_map import TransferMap
-from ocelot.cpbd.beam import Twiss
+from ocelot.cpbd.beam import Twiss, twiss_iterable_to_df
 from ocelot.cpbd.physics_proc import RectAperture, EllipticalAperture
 from ocelot.cpbd.high_order import *
 
@@ -190,7 +191,7 @@ def periodic_twiss(tws, R):
     return tws
 
 
-def twiss(lattice, tws0=None, nPoints=None):
+def twiss(lattice, tws0=None, nPoints=None, return_df=False):
     """
     twiss parameters calculation
 
@@ -214,6 +215,10 @@ def twiss(lattice, tws0=None, nPoints=None):
             tws0.gamma_y = (1. + tws0.alpha_y ** 2) / tws0.beta_y
 
         twiss_list = trace_obj(lattice, tws0, nPoints)
+
+        if return_df:
+            twiss_list = twiss_iterable_to_df(twiss_list)
+
         return twiss_list
     else:
         _logger.warning(' Twiss: no periodic solution. return None')

--- a/unit_tests/cpbd/test_beam.py
+++ b/unit_tests/cpbd/test_beam.py
@@ -1,8 +1,11 @@
+import pytest
 import numpy as np
 
 from ocelot.cpbd.beam import (cov_matrix_from_twiss,
                               cov_matrix_to_parray,
-                              optics_from_moments
+                              optics_from_moments,
+                              Twiss,
+                              twiss_iterable_to_df
                               )
 
 # ex=1.858178000891106e-11,
@@ -55,3 +58,69 @@ def test_cov_matrix_to_parray():
 
 def test_optics_from_moments():
     pass
+
+
+@pytest.fixture
+def a_twiss_dictionary():
+    optics_dict = {'emit_x': 0.34763928534510036,
+                   'emit_y': 0.6790349802898668,
+                   'emit_xn': 0.10046549579167263,
+                   'emit_yn': 0.22230695589625382,
+                   'eigemit_1': 0.4896032635908605,
+                   'eigemit_2': 0.4621735761528035,
+                   'beta_x': 0.1288947746254585,
+                   'beta_y': 0.09036354359497034,
+                   'alpha_x': 0.9597776593035088,
+                   'alpha_y': 0.8390564421996655,
+                   'gamma_x': 0.14540121338731515,
+                   'gamma_y': 0.7244156996636956,
+                   'Dx': 0.010293384598673794,
+                   'Dy': 0.8162183638949975,
+                   'Dxp': 0.4672056535332062,
+                   'Dyp': 0.2994689154547381,
+                   'mux': 0.9993182745796386,
+                   'muy': 0.6446622051396393,
+                   'E': 0.5095571020715003,
+                   's': 0.4799985227868193,
+                   'q': 0.6522847419197526,
+                   'x': 0.2852771630754366,
+                   'y': 0.5087154088422419,
+                   'p': 0.6810071075764375,
+                   'tau': 0.067116684235901,
+                   'xp': 0.140082529580558,
+                   'yp': 0.2847354314054312,
+                   'xx': 0.48184506797105153,
+                   'xpx': 0.6798247854790131,
+                   'pxpx': 0.26775563153047577,
+                   'yy': 0.2375805309768111,
+                   'ypy': 0.8878538454820061,
+                   'pypy': 0.33197187208200896,
+                   'tautau': 0.7690410387155361,
+                   'xy': 0.5916561916755728,
+                   'pxpy': 0.790476675553196,
+                   'xpy': 0.2717175021299518,
+                   'ypx': 0.6684978344712186,
+                   "id": "Hello my friends!"
+                   }
+    return optics_dict
+
+@pytest.fixture
+def a_twiss_instance(a_twiss_dictionary):
+    result = Twiss()
+    for key, value in a_twiss_dictionary.items():
+        if not hasattr(result, key):
+            raise AttributeError(f"Twiss instance has no {key} attribute.")
+        setattr(result, key, value)
+    return result
+
+def test_Twiss_to_series(a_twiss_instance, a_twiss_dictionary):
+    # Random numbers between 0 and 1 just for fun.
+    twiss = a_twiss_instance
+    assert dict(twiss.to_series()) == a_twiss_dictionary
+
+def test_twiss_iterable_to_df(a_twiss_instance):
+    twisses = [a_twiss_instance, a_twiss_instance]
+
+    twiss_df = twiss_iterable_to_df(twisses)
+    assert dict(twiss_df.iloc[0]) == dict(twisses[0].to_series())
+    assert dict(twiss_df.iloc[1]) == dict(twisses[1].to_series())


### PR DESCRIPTION
track and twiss returning an iterable of Twiss instances can be difficult and unwieldy.  Having to do list
comprehensions to look at any variable is annoying.  To manipulate the data will then
also require a conversion to a np.array.  Far easier to just use a Pandas DataFrame.  I
also include a method for converting a Twiss instance to a Pandas Series.  The kwarg
return_df are for the two functions track and twiss.