### PR TITLE
fix tfs adaptor regarding its tests

### DIFF
--- a/ocelot/adaptors/tfs.py
+++ b/ocelot/adaptors/tfs.py
@@ -1,6 +1,14 @@
 import ocelot.cpbd.elements as elements
 from ocelot.cpbd.beam import Twiss
-import tfs
+import logging
+
+try:
+    import tfs
+except ImportError:
+    logging.getLogger(__file__).warning(
+        f"Optional package: TFS-Pandas missing.  {__name__} will lack functionality."
+    )
+
 
 
 
@@ -41,14 +49,6 @@ def optics_from_tfs(tfs_table):
     twiss.yp = first["PY"]
 
     return twiss
-
-def convert_tfs_lattice(tfsfilename, converter=None):
-    if converter is None:
-        converter = MADXLatticeConverter()
-
-    for row in self.tfs.itertuples():
-        yield self._dispatch(row)
-
 
 
 class UnsupportedMADXElementType(RuntimeError): pass


### PR DESCRIPTION
Now fails gracefully if the optional dependency (tfs-pandas) is missing.  Also delete dead code that should never be used. Add friendly warning if the tfs-pandas module is missing and the user tries to import the tfs adaptor.  The TFS adaptor tests are skipped if the optional package is missing.