### PR TITLE
astra2ocelot, charge cannot be negative in ocelot, -ve implied.

### DIFF
--- a/ocelot/adaptors/astra2ocelot.py
+++ b/ocelot/adaptors/astra2ocelot.py
@@ -171,9 +171,9 @@ def astraBeam2particleArray(filename, print_params=True):
 
     if P0[0, 7] == 0:
         xp = P0[1:, :6]
-        charge_array = -P0[1:, 7] * 1e-9  # charge in nC -> in C
+        charge_array = abs(P0[1:, 7]) * 1e-9  # charge in nC -> in C
     else:
-        charge_array = -P0[:, 7] * 1e-9  # charge in nC -> in C
+        charge_array = abs(P0[:, 7]) * 1e-9  # charge in nC -> in C
         xp = P0[:, :6]
         xp[0, 2] = 0.
         xp[0, 5] = 0.


### PR DESCRIPTION
astra2ocelot, charge cannot be negative in ocelot, -ve implied.

If for some reason the charge being read from OCELOT is positive, then you get a
negative charge when multiplying by -1.  this gives nonsense results, positive
charge is assumed in a number of places in ocelot.  indeed in the astra manual it
says (https://www.desy.de/~mpyflo/Astra_manual/Astra-Manual_V3.2.pdf):

    The sign of the charge specified in the column 8 [macro charge] is not relevant

so it is wrong to assume that it is negative in astra for electrons, and wrong to multiply by -1