### PR TITLE
silence printout in SaferCSR class

### DIFF
--- a/ocelot/cpbd/csr.py
+++ b/ocelot/cpbd/csr.py
@@ -1174,8 +1174,6 @@ class SaferCSR(CSR):
 
 
         crit = self._derbenev_criterion(size, bunch_length, bending_radius)
-        print(f"Position = {self.z0}"
-              f" Derebenv Criterion = {crit}")
         # Criterion should be must less than 1 for 1D to be valid.  As it's "much
         # less than", we say <0.5 by default...
         if crit > self.derbenev_criterion:


### PR DESCRIPTION
delete unnecessary printout on every step.  only print warnings when needed.