### PR TITLE
In ParticleArray.sort(in_place=True): also sort the q_array

### DIFF
--- a/ocelot/cpbd/beam.py
+++ b/ocelot/cpbd/beam.py
@@ -876,6 +876,7 @@ class ParticleArray:
 
         if in_place:
             self.rparticles = self.rparticles[..., indices]
+            self.q_array = self.q_array[indices]
 
         return indices
 


### PR DESCRIPTION
On the off chance the macro particle charges are different!  Otherwise this will be wrong...