### PR TITLE
Delete class Sequence and module sequence that does nothing.

### DIFF
--- a/ocelot/__init__.py
+++ b/ocelot/__init__.py
@@ -14,7 +14,7 @@ __all__ = ['Twiss', "Beam", "Particle", "get_current", "get_envelope", "generate
             "get_map", "MethodTM", "SecondTM", "KickTM", "CavityTM", "UndulatorTestTM",        # optics
 
             'Element', 'Multipole', 'Quadrupole', 'RBend', "Matrix", "UnknownElement",              # elements
-            'SBend', 'Bend', 'Drift', 'Undulator', 'Hcor',  "Sequence", "Solenoid", "TDCavity",     # elements
+            'SBend', 'Bend', 'Drift', 'Undulator', 'Hcor', "Solenoid", "TDCavity",     # elements
             'Vcor', "Sextupole", "Monitor", "Marker", "Octupole", "Cavity",  "Aperture",   # elements
 
             "match", "match_tunes",                                                          # match

--- a/ocelot/cpbd/elements/__init__.py
+++ b/ocelot/cpbd/elements/__init__.py
@@ -1,6 +1,7 @@
-__all__ = ['UnknownElement', 'Aperture', 'Bend', 'Cavity', 'Drift', 'Element', 'Hcor', 'Marker',
-           'Matrix', 'Monitor', 'Multipole', 'Octupole', 'Pulse', 'Quadrupole', 'RBend', 'SBend', 'Sextupole',
-           'Solenoid', 'TDCavity', 'TWCavity', 'Undulator', 'Vcor', 'XYQuadrupole', 'Sequence']
+__all__ = ['UnknownElement', 'Aperture', 'Bend', 'Cavity', 'Drift', 'Element',
+           'Hcor', 'Marker', 'Matrix', 'Monitor', 'Multipole', 'Octupole', 'Pulse',
+           'Quadrupole', 'RBend', 'SBend', 'Sextupole', 'Solenoid', 'TDCavity',
+           'TWCavity', 'Undulator', 'Vcor', 'XYQuadrupole']
 
 from ocelot.cpbd.elements.aperture import Aperture
 from ocelot.cpbd.elements.bend import Bend
@@ -17,7 +18,6 @@ from ocelot.cpbd.elements.pulse import Pulse
 from ocelot.cpbd.elements.quadrupole import Quadrupole
 from ocelot.cpbd.elements.rbend import RBend
 from ocelot.cpbd.elements.sbend import SBend
-from ocelot.cpbd.elements.sequence import Sequence
 from ocelot.cpbd.elements.sextupole import Sextupole
 from ocelot.cpbd.elements.solenoid import Solenoid
 from ocelot.cpbd.elements.tdcavity import TDCavity

--- a/ocelot/cpbd/elements/sequence.py
+++ b/ocelot/cpbd/elements/sequence.py
@@ -1,3 +1,0 @@
-class Sequence:
-    def __init__(self, l=0, refer=0):
-        self.l = l


### PR DESCRIPTION
Just pollutes the namespace, has no functionality as far as I can tell, so slows down import for example.  Also clashes with `typing.Sequence` in Python standard library package `typing`, which is annoying.