### PR TITLE
if non iterable is passed to flatten function, then just yield it.

### DIFF
--- a/ocelot/cpbd/magnetic_lattice.py
+++ b/ocelot/cpbd/magnetic_lattice.py
@@ -112,21 +112,24 @@ def merger(lat, remaining_types=None, remaining_elems=None, init_energy=0.):
 
 def flatten(iterable: Iterator[Any]) -> Generator[Any, None, None]:
     """Flatten arbitrarily nested iterable.
-    Special case for strings that avoids infinite recursion.
+    Special case for strings that avoids infinite recursion.  Non iterables passed
+    as arguments are yielded.
 
     :param iterable: Any iterable to be flattened.
     :raises: RecursionError
 
     """
     def _flatten(iterable):
-        for item in iterable:
-            try:
-                iter(item)
-            except TypeError:
-                yield item
-            else:
-                yield from _flatten(item)
-
+        try:
+            for item in iterable:
+                try:
+                    iter(item)
+                except TypeError:
+                    yield item
+                else:
+                    yield from _flatten(item)
+        except TypeError: # If iterable isn't actually iterable, then yield it.
+            yield iterable
     try:
         yield from _flatten(iterable)
     except RecursionError:


### PR DESCRIPTION
tests pass.  still failing tests but they failed before the flatten function and i think are specific somehow to my platform.  

with this commit:

<img width="1550" alt="Screenshot 2022-02-23 at 10 50 15" src="https://user-images.githubusercontent.com/11847924/155295719-0627124d-3084-465b-a930-65c0d22bea63.png">


before bad flatten function was introduced (tested with ef58a270)

<img width="1550" alt="Screenshot 2022-02-23 at 11 02 11" src="https://user-images.githubusercontent.com/11847924/155297653-39d1b3a1-fe4f-4b40-895f-a484fb862407.png">

