### PR TITLE
Raise when rk_traj is selected but without an energy in CSR.prepare

### DIFF
--- a/ocelot/cpbd/csr.py
+++ b/ocelot/cpbd/csr.py
@@ -104,6 +104,10 @@ def sample_1(i, a, b, c):
     return y
 
 
+class CSRConfigurationError(RuntimeError):
+    pass
+
+
 class Smoothing:
     def __init__(self):
         self.print_log = False
@@ -860,6 +864,11 @@ class CSR(PhysProc):
         if self.pict_debug:
             self.napply = 0
             self.total_wake = 0
+
+        if self.energy is None and self.rk_traj:
+            raise CSRConfigurationError(
+                "RK trajectory calc set but CSR.energy left unset."
+            )
 
         self.z_csr_start = sum([p.l for p in lat.sequence[:self.indx0]])
         p = Particle()


### PR DESCRIPTION
Can't happen in the init as the init doesn't actually intialise, it is set
manually.  So has to happen in prepare.

If a user thinks: "ok I would like to use `rk_traj` in `CSR`", they may easily forget to also set `energy`.  If they don't set it, they simply get incorrect results, but no explanation why.  This is why.  It is never correct to set `rk_traj` without also `energy`, so raise an exception.