### PR TITLE
Copy beam physics proc with ParticleArray.copy method

### DIFF
--- a/ocelot/cpbd/beam.py
+++ b/ocelot/cpbd/beam.py
@@ -16,6 +16,9 @@ from ocelot.cpbd.reswake import pipe_wake
 
 import pandas as pd
 
+from typing import TypeVar
+
+TypeParticleArray = TypeVar("TypeParticleArray", bound="ParticleArray")
 
 _logger = logging.getLogger(__name__)
 
@@ -941,6 +944,9 @@ class ParticleArray:
         self.rparticles = np.delete(self.rparticles, inds, 1)
         self.q_array = np.delete(self.q_array, inds, 0)
 
+    def copy(self) -> TypeParticleArray:
+        """Return a copy of this ParticleArray instance."""
+        return deepcopy(self)
 
 def recalculate_ref_particle(p_array):
     pref = np.sqrt(p_array.E ** 2 / m_e_GeV ** 2 - 1) * m_e_GeV

--- a/ocelot/cpbd/physics_proc.py
+++ b/ocelot/cpbd/physics_proc.py
@@ -79,6 +79,19 @@ class SaveBeam(PhysProc):
         save_particle_array(filename=self.filename, p_array=p_array)
 
 
+class CopyBeam(PhysProc):
+    def __init__(self, name=""):
+        super().__init__()
+        self.name = name
+        self.parray = None
+
+    def apply(self, parray, dz):
+        self.parray = parray.copy()
+
+    def __repr__(self):
+        return f"<CopyBeam: {self.name}, at={hex(id(self))}>"
+
+
 class SmoothBeam(PhysProc):
     """
     Physics Process for the beam smoothing. Can be applied when number of particles is not enough.
@@ -349,7 +362,7 @@ class EllipticalAperture(PhysProc):
         inds = inds.reshape(inds.shape[0])
         p_array.delete_particles(inds)
 
-        
+
 class BeamTransform(PhysProc):
     """
     Beam matching

--- a/ocelot/cpbd/physics_proc.py
+++ b/ocelot/cpbd/physics_proc.py
@@ -80,15 +80,18 @@ class SaveBeam(PhysProc):
 
 
 class CopyBeam(PhysProc):
-    def __init__(self, name=""):
+    """Physics process that copies the ParticleArray instance when applied.  Makes
+    most sense to be attached to zero-length elements (e.g. Marker instances)."""
+    def __init__(self, name: str=""):
         super().__init__()
         self.name = name
         self.parray = None
 
-    def apply(self, parray, dz):
+    def apply(self, parray: ParticleArray, dz: float):
+        """Copy the given particle array to self"""
         self.parray = parray.copy()
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"<CopyBeam: {self.name}, at={hex(id(self))}>"
 
 


### PR DESCRIPTION
SaveBeam is nice but also it is useful to have proc that just copies the beam and holds it until later.  Also it is very common to have to keep calling deepcopy on ParticleArray, useful to copy the idea of  `.copy` method on `np.array` instances and have it as a method here.