### PR TITLE
Update Wake-T adaptor

### DIFF
--- a/ocelot/adaptors/wake_t.py
+++ b/ocelot/adaptors/wake_t.py
@@ -6,7 +6,7 @@ with Ocelot.
 
 import numpy as np
 try:
-    from wake_t.driver_witness import ParticleBunch
+    from wake_t import ParticleBunch
     wake_t_installed = True
 except ImportError:
     wake_t_installed = False


### PR DESCRIPTION
This PR updates the Wake-T adaptor so that it works with the latest [0.5.0](https://github.com/AngelFP/Wake-T/releases/tag/v0.5.0) release.