### PR TITLE
limit size of ASCII floating numbers in genesis beam input file

### DIFF
--- a/ocelot/adaptors/genesis.py
+++ b/ocelot/adaptors/genesis.py
@@ -2861,7 +2861,7 @@ def beam_file_str(beam):
     for i in range(beam.len()):
         for attr in attrs:
             if attr in dict:
-                buf = str(getattr(beam,attr)[i])
+                buf = '%.8f' % getattr(beam,attr)[i]
                 f_str = f_str + buf + ' '
         f_str = f_str.rstrip() + '\n'
 


### PR DESCRIPTION
The default version of Genesis 1.3 (version 2) available on the Maxwell cluster (module load genesis/2.0) has problems reading the beam files generated by the genesis2 adaptor and crashes. Weilun suggested to limit the size of the ASCII floats that are written to 8 decimals. Indeed this solved the error.

I have not tested whether the same change is necessary in the radiation file (see line 3160).