### PR TITLE
bugfix KS with wrong shape

### DIFF
--- a/ocelot/cpbd/csr.py
+++ b/ocelot/cpbd/csr.py
@@ -824,7 +824,11 @@ class CSR(PhysProc):
         else:
             w, KS = self.K0_inf_anf(i, traj, w_range[0])
 
-        KS1 = KS[0]
+        try:
+            KS1 = KS[0]
+        except IndexError:
+            KS = [KS]
+            KS1 = KS[0]
 
         # w, idx = np.unique(w, return_index=True)
         # KS = KS[idx]


### PR DESCRIPTION
Some branches of calculating (w, Ks) return Ks as a float, and others return it as an array. This crashes the program when Ks is a float. Here is my suggestion to fix it.