### PR TITLE
make dfl_ap_rect apertures symmetric

### DIFF
--- a/ocelot/optics/wave.py
+++ b/ocelot/optics/wave.py
@@ -2256,7 +2256,10 @@ def dfl_ap_rect(dfl, ap_x=np.inf, ap_y=np.inf):
     
     
     mask = np.zeros_like(dfl.fld[0, :, :])
-    mask[idx_y1:idx_y2, idx_x1:idx_x2] = 1
+    mask[idx_y1:(idx_y2+1), idx_x1:(idx_x2+1)] = 1
+    #                   ^                  ^
+    # also set to 1 elements indexed by idx_x2/idx_y2 (symmetric aperture)
+    #
     mask_idx = np.where(mask == 0)
 
     # dfl_out = deepcopy(dfl)


### PR DESCRIPTION
This patch fixes the apertures applied by `dfl_ap_rect` function. They were asymmetric by 1 cell.

So far, for instance if the ap_x and ap_y are chosen so that only the central pixel is supposed to survive, *no* energy is in the cut transverse plane. This is not correct, the energy in the central cell of the matrix should survive the cut.
