### PR TITLE
skip tests and class defn when h5py is not installed

### DIFF
--- a/ocelot/cpbd/io.py
+++ b/ocelot/cpbd/io.py
@@ -30,10 +30,11 @@ try:
 except ImportError:
     pass
 
+HAS_H5PY = True
 try:
     import h5py
 except ImportError:
-    pass
+    HAS_H5PY = False
 
 _logger = logging.getLogger(__name__)
 
@@ -42,13 +43,14 @@ def is_an_mpi_process():
     return "OMPI_COMM_WORLD_SIZE" in os.environ
 
 
-class HDF5FileWithMaybeMPI(h5py.File):
-    def __init__ (self, *args, **kwargs):
-        if is_an_mpi_process():
-            _logger.debug("Opening h5py with mpi enabled")
-            kwargs.update({"driver": "mpio", "comm": MPI.COMM_WORLD})
-        # self.f = h5py.File(*args, **kwargs)
-        super().__init__(*args, **kwargs)
+if HAS_H5PY:
+    class HDF5FileWithMaybeMPI(h5py.File):
+        def __init__ (self, *args, **kwargs):
+            if is_an_mpi_process():
+                _logger.debug("Opening h5py with mpi enabled")
+                kwargs.update({"driver": "mpio", "comm": MPI.COMM_WORLD})
+            # self.f = h5py.File(*args, **kwargs)
+            super().__init__(*args, **kwargs)
 
 
 class ParameterScanFile:

--- a/unit_tests/cpbd/test_io.py
+++ b/unit_tests/cpbd/test_io.py
@@ -17,6 +17,11 @@ PARRAY0S = [ParticleArray(10), ParticleArray(20)]
 MARKER_NAMES = ["pytest-marker-name-1", "pytest-marker-name-2"]
 FILENAME = "test.hdf5"
 
+try:
+    import h5py
+except ImportError:
+    pytest.skip(reason="No h5py installed", allow_module_level=True)
+
 def assert_parray_equality(first, second):
     np.testing.assert_equal(first.E, second.E)
     np.testing.assert_equal(first.s, second.s)

--- a/unit_tests/cpbd/test_track.py
+++ b/unit_tests/cpbd/test_track.py
@@ -22,6 +22,11 @@ MARKER_NAMES = ["pytest-marker-name-1", "pytest-marker-name-2"]
 PARAMETER_VALUES = [0.1, 0.3]
 FILENAME = "test.hdf5"
 
+try:
+    import h5py
+except ImportError:
+    pytest.skip(reason="No h5py installed", allow_module_level=True)
+
 @pytest.fixture
 def navigator():
     b1 = SBend(l=0.5, angle=-0.5)


### PR DESCRIPTION
this saves crashes and failed tests when this optional dependency isn't installed