### PR TITLE
g4adaptor: bugfix for steady-state simulations

### DIFF
--- a/ocelot/adaptors/genesis4.py
+++ b/ocelot/adaptors/genesis4.py
@@ -311,7 +311,10 @@ class Genesis4Input:
         # TODO: decide whether error raising is needed if co-exist e.g. importbeam and beam or importfield and field
     def check_consistency_round2(self):
         _logger.info('CL 2023-Aug-02: May need to re-implement this later')
-		
+
+
+
+
     def populate_sequence_beam_array(self, beam_name_list_id, beam=None):
         # Info: profile_file_multi feature was implemented into
         # "GENESIS 1.3" v4 developer version by C. Lechner in Sept-2021.
@@ -396,14 +399,19 @@ class Genesis4Input:
         if isinstance(beam, BeamArray):
             beam_pk = beam.pk()
             _logger.warning(
-                'at the moment method beam_to_sequence_beam parses a single beam slice; peak current value is taken')
+                'at the moment method populate_sequence_beam parses a single beam slice; peak current value is taken')
         elif isinstance(beam, Beam):
             beam_pk = beam
         else:
             raise TypeError('beam should be an instance of BeamArray or Beam')
+        # Special handling required since steady-state simulations typically do not use '&time' block
+        got_time_block = 'time' in self.sequence
+        if got_time_block:
+            self.sequence['time'].slen = np.amax(beam.s) - np.amin(beam.s)
+        else:
+            _logger.warning('Sequence does not contain \'time\' element. This is not an issue for steady-state simulations.')
+
         self.sequence['setup'].gamma0 = beam_pk.g
-        # FIXME: bugfix needed for steady-state simulations (these don't have a time element). See populate_sequence_beam_array.
-        self.sequence['time'].slen = np.amax(beam.s) - np.amin(beam.s)
         self.sequence[name_list_id].gamma = beam_pk.g  # from [GeV] to [units of the electron rest mass]
         self.sequence[name_list_id].delgam = beam_pk.dg
         self.sequence[name_list_id].current = beam_pk.I
@@ -443,6 +451,9 @@ class Genesis4Input:
     #         except:
     #             # _logger.debug...
     #             pass
+
+
+
 
 
 class Genesis4Attachments:

--- a/ocelot/adaptors/genesis4.py
+++ b/ocelot/adaptors/genesis4.py
@@ -325,8 +325,16 @@ class Genesis4Input:
                 _logger.warning(ind_str + 'no beam_array to populate')
             else:
                 self.attachments.beam[beam_name_list_id] = beam
+                # Update simulation parameters: gamma0 in '&setup' and slen in '&time'
                 self.sequence['setup'].gamma0 = np.mean(beam.g)
-                self.sequence['time'].slen = np.amax(beam.s) - np.amin(beam.s)
+                # Special handling required since steady-state simulations typically do not use '&time' block
+                got_time_block = 'time' in self.sequence
+                if got_time_block:
+                    self.sequence['time'].slen = np.amax(beam.s) - np.amin(beam.s)
+                else:
+                    _logger.warning('Sequence does not contain \'time\' element. This is not an issue for steady-state simulations.')
+        ###
+        ###
         new_sequence = {}
         for name_list_id, name_list in self.sequence.items():
             # If it is not the 'beam' we are looking for, just propagate to the new sequence

--- a/ocelot/adaptors/genesis4.py
+++ b/ocelot/adaptors/genesis4.py
@@ -402,6 +402,7 @@ class Genesis4Input:
         else:
             raise TypeError('beam should be an instance of BeamArray or Beam')
         self.sequence['setup'].gamma0 = beam_pk.g
+        # FIXME: bugfix needed for steady-state simulations (these don't have a time element). See populate_sequence_beam_array.
         self.sequence['time'].slen = np.amax(beam.s) - np.amin(beam.s)
         self.sequence[name_list_id].gamma = beam_pk.g  # from [GeV] to [units of the electron rest mass]
         self.sequence[name_list_id].delgam = beam_pk.dg

--- a/ocelot/adaptors/genesis4.py
+++ b/ocelot/adaptors/genesis4.py
@@ -335,7 +335,7 @@ class Genesis4Input:
                 if got_time_block:
                     self.sequence['time'].slen = np.amax(beam.s) - np.amin(beam.s)
                 else:
-                    _logger.warning('Sequence does not contain \'time\' element. This is not an issue for steady-state simulations.')
+                    _logger.info('Sequence does not contain \'time\' element. This is not an issue for steady-state simulations.')
         ###
         ###
         new_sequence = {}
@@ -409,7 +409,7 @@ class Genesis4Input:
         if got_time_block:
             self.sequence['time'].slen = np.amax(beam.s) - np.amin(beam.s)
         else:
-            _logger.warning('Sequence does not contain \'time\' element. This is not an issue for steady-state simulations.')
+            _logger.info('Sequence does not contain \'time\' element. This is not an issue for steady-state simulations.')
 
         self.sequence['setup'].gamma0 = beam_pk.g
         self.sequence[name_list_id].gamma = beam_pk.g  # from [GeV] to [units of the electron rest mass]


### PR DESCRIPTION
Solve issue in functions `populate_sequence_beam_array` and `populate_sequence_beam` caused by absence of 'time' element in sequence. This is for instance relevant when setting up steady-state simulations.