### PR TITLE
current cut-off in G4 plots

### DIFF
--- a/ocelot/gui/genesis4_plot.py
+++ b/ocelot/gui/genesis4_plot.py
@@ -505,8 +505,14 @@ def subfig_z_energy_espread_bunching(ax_energy, out, zi=None, x_units='um', lege
     except Error as err:
         Iz = out.I
 
-    # first steps with hard-coded cutoff
-    Icutoff=100 # None
+    # If 'plot_gen4_out_z' is called with Genesis4Output class instances
+    # as argument (as returned by 'read_gout4', for instance), obtain
+    # cutoff specification from there
+    Icutoff=None
+    if isinstance(out,Genesis4Output):
+        if 'x_Icutoff' in dir(out):
+            Icutoff=out.x_Icutoff
+
     if Icutoff is not None:
         idx_slices_to_plot = np.where(Iz>=Icutoff)
     else:

--- a/ocelot/gui/genesis4_plot.py
+++ b/ocelot/gui/genesis4_plot.py
@@ -498,10 +498,26 @@ def subfig_z_energy_espread_bunching(ax_energy, out, zi=None, x_units='um', lege
     
     if zi == None:
         zi = -1
+
+    # obtain current profile (from function 'subfig_z_power_curr')
+    try:
+        Iz = out.Iz(zi)
+    except Error as err:
+        Iz = out.I
+
+    # first steps with hard-coded cutoff
+    Icutoff=100 # None
+    if Icutoff is not None:
+        idx_slices_to_plot = np.where(Iz>=Icutoff)
+    else:
+        idx_slices_to_plot = np.where(Iz>=-1) # selects *all* slices
+    idx_slices_to_plot = idx_slices_to_plot[0] # make it 1-D array
     
-    ax_energy.plot(x, out.h5['Beam/energy'][zi, :] * m_e_GeV, 'b-', x,
-                   (out.h5['Beam/energy'][zi, :] + out.h5['Beam/energyspread'][zi, :]) * m_e_GeV, 'r--', x,
-                   (out.h5['Beam/energy'][zi, :] - out.h5['Beam/energyspread'][zi, :]) * m_e_GeV, 'r--')
+    ax_energy.plot(
+      x[idx_slices_to_plot], out.h5['Beam/energy'][zi, idx_slices_to_plot] * m_e_GeV, 'b-',
+      x[idx_slices_to_plot], (out.h5['Beam/energy'][zi, idx_slices_to_plot] + out.h5['Beam/energyspread'][zi, idx_slices_to_plot]) * m_e_GeV, 'r--',
+      x[idx_slices_to_plot], (out.h5['Beam/energy'][zi, idx_slices_to_plot] - out.h5['Beam/energyspread'][zi, idx_slices_to_plot]) * m_e_GeV, 'r--'
+    )
     ax_energy.set_ylabel(r'$E\pm\sigma_E$ [GeV]')
     # ax_energy.ticklabel_format(axis='y', style='sci', scilimits=(-3, 3), useOffset=False)
     ax_energy.ticklabel_format(useOffset=False, style='plain')
@@ -509,7 +525,7 @@ def subfig_z_energy_espread_bunching(ax_energy, out, zi=None, x_units='um', lege
     # plt.yticks(plt.yticks()[0][0:-1])
     
     ax_bunching = ax_energy.twinx()
-    ax_bunching.plot(x, out.h5['Beam/bunching'][zi, :], 'grey', linewidth=0.5)
+    ax_bunching.plot(x[idx_slices_to_plot], out.h5['Beam/bunching'][zi, idx_slices_to_plot], 'grey', linewidth=0.5)
     ax_bunching.set_ylabel('Bunching')
     ax_bunching.set_ylim(ymin=0)
     ax_bunching.grid(False)
@@ -520,6 +536,11 @@ def subfig_z_energy_espread_bunching(ax_energy, out, zi=None, x_units='um', lege
     ax_bunching.tick_params(axis='y', which='both', colors='grey')
     ax_bunching.yaxis.label.set_color('grey')
     ax_energy.set_xlim([x[0], x[-1]])
+    if Icutoff is not None:
+        # info about current cutoff
+        ax_bunching.text(0.02, 0.98, 'I$_{cutoff}$ = '+f'{(Icutoff/1e3):.2f} kA',
+            fontsize=12, horizontalalignment='left',
+            verticalalignment='top', transform=ax_bunching.transAxes, color='black')
 
 
 @if_plottable


### PR DESCRIPTION
Currently this is implemented for the plot panel generated by function `subfig_z_energy_espread_bunching`. 
Typical use case:
```
gout = read_gout4('./simout/demo.out.h5’)
gout.x_Icutoff=100
plot_gen4_out_z(gout, z=gout.z[-1], showfig=True, savefig=False)
```

If the propery `x_Icutoff` of Genesis4Output instance returned by `read_gout4` is not set, the behavior of the plotting code is unchanged.

The advantage becomes visible when plotting results of one4one simulations with small currents on the margins of the bunch. In the screenshot on the left (test simulation with one4one=1), slices with current=0A are plotted with zero avg. energy (note the range of the vertical energy axis). In the plot on the right these slices are ignored and one can see the energy (spread) profile along the bunch. In addition, in a one4one scenario with slices having just a few particles, the bunching factor for some slices would be close to 1, forcing the range of the bunching factor axis to be 0..1.
![image](https://github.com/ocelot-collab/ocelot/assets/49592618/b31161a9-81f3-4a5c-b240-851ded0f4fc0)

