### PR TITLE
fix incorrect handling of lattice elements not known to the adaptor for "GENESIS 1.3", v4

### DIFF
--- a/ocelot/adaptors/genesis4.py
+++ b/ocelot/adaptors/genesis4.py
@@ -924,7 +924,7 @@ def gen4_lat_str(lat, line_name='LINE', zstop=np.inf):
             # Unknown element type, replace by drift to get cell length right (while ignoring l=0 elements)
             if element.l==0:
                 _logger.warning('Unknown element {} with length {}'.format(str(element), element.l))
-                continue
+                continue # not writing a line to the lattice file
             #
             _logger.warning('Unknown element {} with length {}\n replacing with drift'.format(str(element), element.l))
             element_name = element_num + 'UNKNOWN'


### PR DESCRIPTION
The adaptor did not write the drifts replacing unknown elements to the generated lattice file, resulting in the lattice period in GENESIS to be shorter by the total length of the unknown elements.

More information is provided in the corresponding bug report https://github.com/ocelot-collab/ocelot/issues/212 .