### PR TITLE
EuXFEL lattice generation functions: improvements/bugfixes 2

### DIFF
--- a/demos/fel/demo_lat_matchN2.py
+++ b/demos/fel/demo_lat_matchN2.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+
+# Christoph Lechner, European XFEL, 2024-03-01
+#
+# Demo of upgraded create_fel_lattice function.
+# . Matches a FODO cell containing two undulators. This is
+#   possible thanks to new functionality in create_fel_lattice.
+# . Finally, a GENESIS4 lattice file is written.
+
+# import from Ocelot main modules and functions
+import ocelot
+from ocelot.adaptors.genesis4 import *
+from ocelot.gui.beam_plot import *
+from ocelot.utils.xfel_utils import create_fel_beamline
+
+from copy import deepcopy
+
+### Test that we always get the requested number of undulators ###
+for Nundreq in range(2,38):
+    test_lat_pkg = create_fel_beamline('sase1', override_und_N=Nundreq)
+    test_lat, _, _ = test_lat_pkg
+    ucntr=0
+    for ele in test_lat.sequence:
+        if isinstance(ele,Undulator):
+            ucntr+=1
+    print(f'{Nundreq} {ucntr}')
+    if Nundreq!=ucntr:
+	    raise ValueError('error: undulator counts do not match')
+
+print('ok, we always get the requested number of undulators')
+
+### Match demo ###
+# Shorter lattice with SASE1-type FODO (added by CL to OCELOT in Feb 2024)
+# New feature added in March-2024: Request complete final half-cell, allowing matching two-undulator-cell lattice
+sase_lat_pkg = create_fel_beamline('sase1', override_und_N=2, final_halfcell_complete=True)
+sase_lat, _, _ = sase_lat_pkg
+print(str(sase_lat))
+
+betaavg = 20 # m
+Ephot = 9000 # eV
+beam = generate_beam(E=14, dE=0.003, I=5000, l_beam=1e-6, l_window=1.5e-6, shape='flattop', emit_n=0.4e-6, beta=betaavg, chirp=0)
+prepare_el_optics(beam, sase_lat_pkg, E_photon=Ephot, beta_av=betaavg)
+
+write_gen4_lat({'LM':sase_lat}, filepath='./lat_matched.lat')
+
+

--- a/demos/fel/demo_lat_matchN2.py
+++ b/demos/fel/demo_lat_matchN2.py
@@ -33,6 +33,7 @@ print('ok, we always get the requested number of undulators')
 # Shorter lattice with SASE1-type FODO (added by CL to OCELOT in Feb 2024)
 # New feature added in March-2024: Request complete final half-cell, allowing matching two-undulator-cell lattice
 sase_lat_pkg = create_fel_beamline('sase1', override_und_N=2, final_halfcell_complete=True)
+# sase_lat_pkg = create_fel_beamline('sase1')
 sase_lat, _, _ = sase_lat_pkg
 print(str(sase_lat))
 
@@ -41,6 +42,24 @@ Ephot = 9000 # eV
 beam = generate_beam(E=14, dE=0.003, I=5000, l_beam=1e-6, l_window=1.5e-6, shape='flattop', emit_n=0.4e-6, beta=betaavg, chirp=0)
 prepare_el_optics(beam, sase_lat_pkg, E_photon=Ephot, beta_av=betaavg)
 
+# drop lattice file
 write_gen4_lat({'LM':sase_lat}, filepath='./lat_matched.lat')
+
+
+
+### Draw plot ###
+tws0 = Twiss()
+tws0.beta_x = beam.beta_x[0]
+tws0.beta_y = beam.beta_y[0]
+tws0.alpha_x = beam.alpha_x[0]
+tws0.alpha_y = beam.alpha_y[0]
+print(tws0)
+
+# import from Ocelot graphical modules
+from ocelot.gui.accelerator import *
+
+tws = twiss(sase_lat, tws0, nPoints=500) # nPoints gives beta functions more natual appearance (for instance: parabolic in drifts)
+plot_opt_func(sase_lat, tws, legend=False)
+plt.show()
 
 

--- a/ocelot/utils/xfel_utils.py
+++ b/ocelot/utils/xfel_utils.py
@@ -265,14 +265,35 @@ def create_fel_lattice(und_N = 35,
 
     # print(f'und_N={und_N}: cell_N={cell_N}, cell_N_last={cell_N_last}')
 
+    '''
+    If False, even number of undulators results in final
+    beamline element to be the last undulator.
+    This was the behavior before this new feature was added in March-2024
+    and is therefore the default (it prevents matching for Nund=2).
+    If True, all undulator half-cells are identical.
+    '''
+    print(kwargs)
+    # False is default value, not changing behavior before March-2024 unless requested by user
+    final_halfcell_complete=kwargs.get('final_halfcell_complete', False)
+
     if quad_start == 'd':
-        cell = (und, cx, cy, d1, qf, phs, d2, und, cx, cy, d1, qd, phs, d2) 
+        cell       = (und, cx, cy, d1, qf, phs, d2,
+                      und, cx, cy, d1, qd, phs, d2) 
         extra_fodo = (und, cx, cy, d2, qdh)
-        lat = (und, cx, cy, d1, qd, phs, d2) + cell_N * cell + cell_N_last * (und,)
+        if final_halfcell_complete==False:
+            fc     = (und,)
+        else:
+            fc     = (und, cx, cy, d1, qf, phs, d2)
+        lat        = (und, cx, cy, d1, qd, phs, d2) + cell_N*cell + cell_N_last*fc
     elif quad_start == 'f':
-        cell = (und, cx, cy, d1, qd, phs, d2, und, cx, cy, d1, qf, phs, d2) 
+        cell       = (und, cx, cy, d1, qd, phs, d2,
+                      und, cx, cy, d1, qf, phs, d2) 
         extra_fodo = (und, cx, cy, d2, qfh)
-        lat = (und, cx, cy, d1, qf, phs, d2) + cell_N * cell + cell_N_last * (und,)
+        if final_halfcell_complete==False:
+            fc     = (und,)
+        else:
+            fc     = (und, cx, cy, d1, qd, phs, d2)
+        lat        = (und, cx, cy, d1, qf, phs, d2) + cell_N*cell + cell_N_last*fc
     
     lat = MagneticLattice(lat)
     
@@ -330,7 +351,7 @@ def create_fel_lattice_tmp(und_N = 34,
     return (MagneticLattice(lat), None, cell)
 
 
-def create_fel_beamline(beamline = 'sase1', inters_phi=0, inters_K = "K_und", *, override_und_N=None):
+def create_fel_beamline(beamline = 'sase1', inters_phi=0, inters_K = "K_und", *, override_und_N=None, final_halfcell_complete=False):
     '''
     If provided, parameter override_und_N allows to adjust the number of undulator cells in the generated beamline.
     '''
@@ -350,8 +371,9 @@ def create_fel_beamline(beamline = 'sase1', inters_phi=0, inters_K = "K_und", *,
                         quad_K = 0,
                         phs_L = 0.0,
                         quad_start = 'd',
-                        beamline_name = beamline
-                            )
+                        beamline_name = beamline,
+                        final_halfcell_complete = final_halfcell_complete
+                    )
     elif beamline in ['sase3', 3, 'EuXFEL_SASE3']:
         und_N = 21 # default value
         if override_und_N is not None:
@@ -368,8 +390,9 @@ def create_fel_beamline(beamline = 'sase1', inters_phi=0, inters_K = "K_und", *,
                         quad_K = 0,
                         phs_L = 0.0,
                         quad_start = 'd',
-                        beamline_name = beamline
-                            )
+                        beamline_name = beamline,
+                        final_halfcell_complete = final_halfcell_complete
+                    )
     else:
         raise ValueError('Unknown beamline')
 

--- a/ocelot/utils/xfel_utils.py
+++ b/ocelot/utils/xfel_utils.py
@@ -260,8 +260,10 @@ def create_fel_lattice(und_N = 35,
         cell_N = 0
         cell_N_last = 0
     else:
-        cell_N = np.floor((und_N - 1)/2).astype(int)
-        cell_N_last = int((und_N - 1)/2%2)
+        cell_N = np.floor((und_N-1)/2).astype(int)
+        cell_N_last = int((und_N-1)%2)
+
+    # print(f'und_N={und_N}: cell_N={cell_N}, cell_N_last={cell_N_last}')
 
     if quad_start == 'd':
         cell = (und, cx, cy, d1, qf, phs, d2, und, cx, cy, d1, qd, phs, d2) 

--- a/ocelot/utils/xfel_utils.py
+++ b/ocelot/utils/xfel_utils.py
@@ -272,7 +272,6 @@ def create_fel_lattice(und_N = 35,
     and is therefore the default (it prevents matching for Nund=2).
     If True, all undulator half-cells are identical.
     '''
-    print(kwargs)
     # False is default value, not changing behavior before March-2024 unless requested by user
     final_halfcell_complete=kwargs.get('final_halfcell_complete', False)
 

--- a/unit_tests/utils_test/xfel_utils_test.py
+++ b/unit_tests/utils_test/xfel_utils_test.py
@@ -1,0 +1,34 @@
+# C. Lechner, European XFEL, 20240316
+
+from ocelot import *
+from ocelot.utils.xfel_utils import create_fel_beamline
+
+def helper_count_undulators(pkg):
+    test_lat, _, _ = pkg
+    ucntr=0
+    for ele in test_lat.sequence:
+        if isinstance(ele,Undulator):
+            ucntr+=1
+    return(ucntr)
+
+def test_create_fel_beamline_Nund_default():
+    # remark CL 20240316: undulator counts also pass test against commit id 16425bd (date: 2023-11-03)
+    test_lat_pkg = create_fel_beamline('sase1')
+    ucntr = helper_count_undulators(test_lat_pkg)
+    assert 37==ucntr
+    #
+    test_lat_pkg = create_fel_beamline('sase2')
+    ucntr = helper_count_undulators(test_lat_pkg)
+    assert 37==ucntr
+    #
+    test_lat_pkg = create_fel_beamline('sase3')
+    ucntr = helper_count_undulators(test_lat_pkg)
+    assert 21==ucntr
+
+# Test that we always get the requested number of undulators #
+def test_create_fel_beamline_Nund():
+    for Nundreq in range(2,38):
+        test_lat_pkg = create_fel_beamline('sase1', override_und_N=Nundreq)
+        # check if number of undulators is as expected
+        ucntr = helper_count_undulators(test_lat_pkg)
+        assert Nundreq==ucntr


### PR DESCRIPTION
Introduces new parameter `final_halfcell_complete` to functions `create_fel_beamline` and `create_fel_lattice`. If True, all generated half-cells are identical, allowing matching of FODO lattice even for beamlines with just `und_N=2` undulators. The default value is False, so unless specified the behavior of the functions remains unchanged.

Fixed remaining issue in function `create_fel_lattice` related to parameter `und_N`, not in all cases the requested number of undulators was returned.

Includes a demo script matching an undulator lattice with just two undulators. After matching the resulting beta functions are displayed.

![image](https://github.com/ocelot-collab/ocelot/assets/49592618/7e9f7ec1-9096-4159-97c9-d3ad5b767831)
