### PR TITLE
callback functionality for lattice writing code (adaptor for "GENESIS 1.3", v4)

### DIFF
--- a/demos/fel/demo_lat_callback.py
+++ b/demos/fel/demo_lat_callback.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+
+# Christoph Lechner, European XFEL, 2024-02-29
+#
+# This demonstrates the newly introduced functionality to
+# manipulate "GENESIS 1.3" v4 lattices during the generation phase.
+#
+# In this demo, the same lattice is written twice:
+# . one time with explicit 'aw' values (default behavior)
+# . one time with references to a sequence (this a new feature added
+#   by CL, available in stable "GENESIS 1.3", v4 releases in early 2024)
+
+# import from Ocelot main modules and functions
+import ocelot
+from ocelot.adaptors.genesis4 import *
+from ocelot.gui.beam_plot import *
+from ocelot.utils.xfel_utils import create_fel_beamline
+
+from copy import deepcopy
+
+
+
+# Demo for G4 adaptor lattice callback:
+# Generates undulator beamline lattice with aw values from sequence.
+# This is based on modified code from OCELOT genesis4 adaptor
+def my_cb_latline(lat, element, eleidx, element_prefix):
+    # print(f'callback idx={eleidx}, data obj={str(element)}')
+
+    ### code from OCELOT genesis4 adaptor ###
+    if isinstance(element,Undulator):
+        element_name = element_prefix + 'UND'
+        if element.Kx == 0 or element.Ky == 0:
+            is_helical = 'false'
+        elif element.Kx == element.Ky:
+            is_helical = 'true'
+        else:
+            _logger.warning(
+                'undulator element with different non-zero Kx and Ky; not implemented; setting to helical')
+            is_helical = 'true'
+        aw = np.sqrt((element.Kx ** 2 + element.Ky ** 2) / 2)
+        # TODO: implement ax,ay,kx,ky,gradx,grady
+        if hasattr(element,'awref'):
+            # aw value is reference to sequence defined in G4 main input file
+            # -> aw parameter of instance of class Undulator has no effect!
+            s = '{:}: UNDULATOR = {{lambdau = {:}, nwig = {:}, aw = @{:}, helical = {:}}};'.format(element_name,
+                                                                                                  element.lperiod,
+                                                                                                  element.nperiods,
+                                                                                                  element.awref, is_helical)
+        else:
+            s = '{:}: UNDULATOR = {{lambdau = {:}, nwig = {:}, aw = {:.6f}, helical = {:}}};'.format(element_name,
+                                                                                                     element.lperiod,
+                                                                                                     element.nperiods,
+                                                                                                     aw, is_helical)
+        return (element_name,s)
+
+    if isinstance(element,Marker) and hasattr(element,'verbatim'):
+        # Another possible application might be a Marker that carries some additional information that is written verbatim to the lattice file.
+        # Use case: lattice elements not supported yet; comments
+        # Note that the callback function currently cannot not prevent the generation of the corresponding lattice elements (the assumption is that every element in the lattice sequence has its corresponding lattice element in the file), but as workaround one can generate one string containing multiple lines (with \n between)
+        pass # no implemented yet
+
+    # It is not one of the special cases -> signal that no special handling required
+    return (None,None)
+    pass
+
+#########################
+### MAIN part of demo ###
+#########################
+# matching procedure verified (same k1 values obtained) for:
+# . standard beamline length (without override_und_N parameter)
+# . override_und_N=2
+
+# If you want the standard lattice
+# sase_lat_pkg = create_fel_beamline('sase1')
+
+'''
+Shorter lattice with SASE1-type FODO (uses functionality added by CL to OCELOT in Feb 2024)
+New feature added in March-2024: Request complete final half-cell
+-> this allows to match two-undulator-cell lattice
+'''
+sase_lat_pkg = create_fel_beamline('sase1', override_und_N=2, final_halfcell_complete=True)
+
+# just in case you want to see the lattice before matching
+#sase_lat, _, _ = sase_lat_pkg
+#print(str(sase_lat))
+
+# set up electron optics, undulator aw value
+betaavg = 20 # m
+Ephot = 9000 # eV
+beam = generate_beam(
+    E=14, dE=0.003,
+    I=5000, shape='flattop', l_beam=1e-6, l_window=1.5e-6,
+    emit_n=0.4e-6, beta=betaavg, nslice=2)
+prepare_el_optics(beam, sase_lat_pkg, E_photon=Ephot, beta_av=betaavg)
+
+sase_lat, _, _ = sase_lat_pkg
+sase_lat2 = deepcopy(sase_lat)
+#print(str(sase_lat))
+
+# Add custom property to the instances of class Undulator.
+# In the callback function they trigger special functionality as the
+# lattice is written out.
+for ele in sase_lat.sequence:
+    if isinstance(ele,Undulator):
+        ele.awref='aw.seq' # add new property to class instance
+for ele in sase_lat2.sequence:
+    if isinstance(ele,Undulator):
+        ele.awref='aw.seq2' # add new property to class instance
+
+### Write lattices ###
+# standard lattice
+write_gen4_lat({'LX':sase_lat,'LY':sase_lat2}, filepath='./lat_noref.lat')
+# lattice with callback function in effect, with aw values replaced by references to sequence
+write_gen4_lat({'LX':sase_lat,'LY':sase_lat2}, filepath='./lat_ref.lat', cb_latline=my_cb_latline)
+
+

--- a/ocelot/adaptors/genesis4.py
+++ b/ocelot/adaptors/genesis4.py
@@ -846,7 +846,70 @@ class Genesis4ParticlesDump:
         # return filename_from_path(self.filePath)
 
 
-def gen4_lat_str(lat, line_name='LINE', zstop=np.inf):
+
+
+
+
+def gen4_lat_elem2str(element, element_num):
+    if isinstance(element, Undulator):
+        element_name = element_num + 'UND'
+
+        if element.Kx == 0 or element.Ky == 0:
+            is_helical = 'false'
+        elif element.Kx == element.Ky:
+            is_helical = 'true'
+        else:
+            _logger.warning(
+                'undulator element with different non-zero Kx and Ky; not implemented; setting to helical')
+            is_helical = 'true'
+        aw = np.sqrt((element.Kx ** 2 + element.Ky ** 2) / 2)
+        # TODO: implement ax,ay,kx,ky,gradx,grady
+        s = '{:}: UNDULATOR = {{lambdau = {:}, nwig = {:}, aw = {:.6f}, helical = {:}}};'.format(element_name,
+                                                                                                 element.lperiod,
+                                                                                                 element.nperiods,
+                                                                                                 aw, is_helical)
+
+    elif isinstance(element, Drift):
+        element_name = element_num + 'DR'
+        s = '{:}: DRIFT = {{l={:}}};'.format(element_name, element.l)
+
+    elif isinstance(element, Quadrupole):
+        # TODO: add dx and dy
+        if element.k1 >= 0:
+            element_name = element_num + 'QF'
+        else:
+            element_name = element_num + 'QD'
+        s = '{:}: QUADRUPOLE = {{l = {:}, k1 = {:.6f} }};'.format(element_name, element.l, element.k1)
+
+    elif isinstance(element, Chicane):
+        element_name = element_num + 'CH'
+        s = '{:}: CHICANE = {{l = {:}, lb = {:}, ld = {}, delay = {:.5e} }};'.format(element_name, element.l,
+                                                                                     element.lb, element.ld,
+                                                                                     element.delay)
+
+    elif isinstance(element, Marker):
+        element_name = element_num + 'M'
+        m_dumpfield = getattr(element, 'dumpfield', 0)
+        m_dumpbeam = getattr(element, 'dumpbeam', 0)
+        m_sort = getattr(element, 'sort', 0)
+        m_stop = getattr(element, 'stop', 0)
+        s = '{:}: MARKER = {{dumpfield = {:}, dumpbeam = {:}, sort = {:}, stop = {:} }};'.format(element_name,
+                                                                                                 m_dumpfield,
+                                                                                                 m_dumpbeam, m_sort,
+                                                                                                 m_stop)
+
+    elif isinstance(element, Phaseshifter):
+        element_name = element_num + 'PH'
+        s = '{:}: PHASESHIFTER = {{l = {:}, phi = {:}}};'.format(element_name, element.l, element.phi)
+
+    else:
+        _logger.warning('Unknown element {} with length {}\n replacing with drift'.format(str(element), element.l))
+        element_name = element_num + 'UNKNOWN'
+        s = '{:}: DRIFT = {{l={:}}};'.format(element_name, element.l)
+
+    return (element_name,s)
+
+def gen4_lat_str(lat, line_name='LINE', zstop=np.inf, cb_latline=None):
     """
     Generates a string of lattice 
     in Genesis4 format
@@ -858,7 +921,6 @@ def gen4_lat_str(lat, line_name='LINE', zstop=np.inf):
     location = 0
 
     for element in lat.sequence:
-
         if location >= zstop:
             break
 
@@ -869,62 +931,17 @@ def gen4_lat_str(lat, line_name='LINE', zstop=np.inf):
         else:
             _logging.warning('[beta] element had no length: {:}'.format(str(element)))
 
-        if isinstance(element, Undulator):
-            element_name = element_num + 'UND'
+        got_info = False
+        if (cb_latline is not None) and callable(cb_latline):
+            qqq = cb_latline(lat, element, len(beamline))
+            if qqq!=(None,None):
+                (element_name,s) = qqq
+                got_info = True
 
-            if element.Kx == 0 or element.Ky == 0:
-                is_helical = 'false'
-            elif element.Kx == element.Ky:
-                is_helical = 'true'
-            else:
-                _logger.warning(
-                    'undulator element with different non-zero Kx and Ky; not implemented; setting to helical')
-                is_helical = 'true'
-            aw = np.sqrt((element.Kx ** 2 + element.Ky ** 2) / 2)
-            # TODO: implement ax,ay,kx,ky,gradx,grady
-            s = '{:}: UNDULATOR = {{lambdau = {:}, nwig = {:}, aw = {:.6f}, helical = {:}}};'.format(element_name,
-                                                                                                     element.lperiod,
-                                                                                                     element.nperiods,
-                                                                                                     aw, is_helical)
-
-        elif isinstance(element, Drift):
-            element_name = element_num + 'DR'
-            s = '{:}: DRIFT = {{l={:}}};'.format(element_name, element.l)
-
-        elif isinstance(element, Quadrupole):
-            # TODO: add dx and dy
-            if element.k1 >= 0:
-                element_name = element_num + 'QF'
-            else:
-                element_name = element_num + 'QD'
-            s = '{:}: QUADRUPOLE = {{l = {:}, k1 = {:.6f} }};'.format(element_name, element.l, element.k1)
-
-        elif isinstance(element, Chicane):
-            element_name = element_num + 'CH'
-            s = '{:}: CHICANE = {{l = {:}, lb = {:}, ld = {}, delay = {:.5e} }};'.format(element_name, element.l,
-                                                                                         element.lb, element.ld,
-                                                                                         element.delay)
-
-        elif isinstance(element, Marker):
-            element_name = element_num + 'M'
-            m_dumpfield = getattr(element, 'dumpfield', 0)
-            m_dumpbeam = getattr(element, 'dumpbeam', 0)
-            m_sort = getattr(element, 'sort', 0)
-            m_stop = getattr(element, 'stop', 0)
-            s = '{:}: MARKER = {{dumpfield = {:}, dumpbeam = {:}, sort = {:}, stop = {:} }};'.format(element_name,
-                                                                                                     m_dumpfield,
-                                                                                                     m_dumpbeam, m_sort,
-                                                                                                     m_stop)
-
-        elif isinstance(element, Phaseshifter):
-            element_name = element_num + 'PH'
-            s = '{:}: PHASESHIFTER = {{l = {:}, phi = {:}}};'.format(element_name, element.l, element.phi)
-
-        else:
-            _logger.warning('Unknown element {} with length {}\n replacing with drift'.format(str(element), element.l))
-            element_name = element_num + 'UNKNOWN'
-            s = '{:}: DRIFT = {{l={:}}};'.format(element_name, element.l)
-            continue
+        if not got_info:
+			# either callback function not defined, or callback function does not override default behavior
+            (element_name,s) = gen4_lat_elem2str(element, element_num)
+            got_info = True
 
         beamline.append(element_name)
         lat_str.append(s)
@@ -939,7 +956,7 @@ def gen4_lat_str(lat, line_name='LINE', zstop=np.inf):
     return lat_str
 
 
-def write_gen4_lat(lattices, filepath, zstop=np.inf):
+def write_gen4_lat(lattices, filepath, zstop=np.inf, cb_latline=None):
     """
     Writing lattice file for Genesis1.3-version4 simulations
     :param lattices: dictionary: {'line_name': ocelot.cpbd.magnetic_lattice.MagneticLattice(), ...}
@@ -963,7 +980,7 @@ def write_gen4_lat(lattices, filepath, zstop=np.inf):
 
     for line_name, lat in zip(lattices.keys(), lattices.values()):
         _logger.debug(ind_str + "line={}, lat={}, zstop={}".format(line_name, type(lat), zstop.get(line_name, np.inf)))
-        lat_str = gen4_lat_str(lat, line_name=line_name, zstop=zstop.get(line_name, np.inf))
+        lat_str = gen4_lat_str(lat, line_name=line_name, zstop=zstop.get(line_name, np.inf), cb_latline=cb_latline)
         f.write(lat_str)
 
     f.write('\n# end of file')

--- a/ocelot/adaptors/genesis4.py
+++ b/ocelot/adaptors/genesis4.py
@@ -924,7 +924,7 @@ def gen4_lat_str(lat, line_name='LINE', zstop=np.inf, cb_latline=None):
         if location >= zstop:
             break
 
-        element_num = line_name + '_' + str(len(beamline) + 1).zfill(3)
+        element_prefix = line_name + '_' + str(len(beamline) + 1).zfill(3)
 
         if hasattr(element, 'l'):
             location += element.l
@@ -933,14 +933,14 @@ def gen4_lat_str(lat, line_name='LINE', zstop=np.inf, cb_latline=None):
 
         got_info = False
         if (cb_latline is not None) and callable(cb_latline):
-            qqq = cb_latline(lat, element, len(beamline))
+            qqq = cb_latline(lat, element, len(beamline), element_prefix)
             if qqq!=(None,None):
                 (element_name,s) = qqq
                 got_info = True
 
         if not got_info:
 			# either callback function not defined, or callback function does not override default behavior
-            (element_name,s) = gen4_lat_elem2str(element, element_num)
+            (element_name,s) = gen4_lat_elem2str(element, element_prefix)
             got_info = True
 
         beamline.append(element_name)


### PR DESCRIPTION
Add support for callback functions to the lattice writing code in OCELOT adaptor for "GENESIS 1.3", v4.

If provided when calling the function `write_gen4_lat`, the callback function gets called for every lattice element while writing a lattice file. This enables the user to override the default behavior and manipulate/replace what is written to the file. As demonstrated by the included demo, one use case is to support new (developer) features of "GENESIS 1.3", v4 without having to modify the adaptor code.

Also reorganized the lattice file generation code in the adaptor.

The included demo script generates a short SASE1-type undulator beamline and matches periodic FODO solution. Then the lattice is written twice:
(i) with standard behavior (not using a callback function); and
(ii) demonstrating the new callback feature, overriding the aw values in the UNDULATOR lines in the lattice with references to a user-defined sequence name (sequences were introduced in "GENESIS 1.3", v4.6.6 and allow for instance for undulator tapering using values generated by a linear polynomial defined in GENESIS main input file).

(Note: The successful execution of the demo script requires the changes in pull request https://github.com/ocelot-collab/ocelot/pull/216 ).