### PR TITLE
adaptor for GENESIS 1.3, v4: add TODO to function clean_output

### DIFF
--- a/ocelot/adaptors/genesis4.py
+++ b/ocelot/adaptors/genesis4.py
@@ -206,6 +206,8 @@ class Genesis4Simulation:
         return out
 
     def clean_output(self):
+        # TODO: replace by better solution:
+        # The combination of 'rm -rf' with wildcards can be dangerous, in particular when the command is executed with 'os.system' and a user-provided string is included into the command string.
         os.system('rm -rf {}*'.format(self.root_path()))
 
 


### PR DESCRIPTION
The current implementation of function clean_output can result in undesired side-effects, i.e. in certain scenarios it could delete more files than intended. Adds TODO to the function.