### PR TITLE
test for callbacks from write_gen4_lat (adaptor for GENESIS 1.3, v4)

### DIFF
--- a/ocelot/adaptors/genesis.py
+++ b/ocelot/adaptors/genesis.py
@@ -3056,6 +3056,7 @@ def transform_beam_twiss(beam, transform=None, s=None):
         else:
             idx = find_nearest_idx(beam.s, s)
 
+        # remark C. Lechner, 2024-04: when running pytest, the use of numpy.matrix in this function raises "PendingDeprecationWarning: the matrix subclass is not the recommended way to represent matrices or deal with linear algebra (see https://docs.scipy.org/doc/numpy/user/numpy-for-matlab-users.html). Please adjust your code to use regular ndarray."
         g1x = np.matrix([[beam.beta_x[idx], beam.alpha_x[idx]],
                          [beam.alpha_x[idx], (1 + beam.alpha_x[idx]**2) / beam.beta_x[idx]]])
 

--- a/ocelot/adaptors/genesis.py
+++ b/ocelot/adaptors/genesis.py
@@ -3706,7 +3706,12 @@ def transform_beam_file(beam_file=None, out_file='tmp.beam', s=None, transform=[
 
     return beam_new
 
-
+'''
+# C. Lechner, 2024-03-24, disabled this test function
+# There aren't any calls to this function and function 'gaussFromTwiss'
+# does not exist in OCELOT code (as of 2024-03).
+# Last git commit containing function gaussFromTwiss: fc89983 (date: 2015-11-17)
+# Function was probably renamed to gauss_from_twiss (see commit id 9a79211, date: 2015-11-17)
 def test_beam_transform(beta1=10.0, alpha1=-0.1, beta2=20, alpha2=2.2):
 
     ex = 1.0
@@ -3735,6 +3740,7 @@ def test_beam_transform(beta1=10.0, alpha1=-0.1, beta2=20, alpha2=2.2):
     xp3 = []
 
     for i in range(5000):
+        # remark, CL, 2024-03: now gauss_from_twiss?
         x_, xp_ = gaussFromTwiss(ex, beta1, alpha1)
         x.append(x_)
         xp.append(xp_)
@@ -3784,7 +3790,7 @@ def test_beam_transform(beta1=10.0, alpha1=-0.1, beta2=20, alpha2=2.2):
     plt.show()
 
     # 49.8131287015 1.12127199531 39.9184728466 -0.897874127701
-
+'''
 
 #import argparse
 #parser = argparse.ArgumentParser(description='Data plotting program.')

--- a/unit_tests/adaptors_test/test_g4adaptor.py
+++ b/unit_tests/adaptors_test/test_g4adaptor.py
@@ -1,5 +1,7 @@
 # C. Lechner, European XFEL, 2024-03-24
 
+import pytest
+
 import ocelot
 from ocelot.adaptors.genesis4 import *
 from ocelot.gui.beam_plot import *
@@ -17,12 +19,12 @@ def my_cb_latline(lat, element, eleidx, element_prefix):
     return (None,None)
 
 
-# Remark: there are 30+ PendingDeprecationWarning messages, related to genesis.py and the use of np.matrix
+# Remark/TODO CL 2024-03: there are 30+ PendingDeprecationWarning messages, related to genesis.py and the use of np.matrix
+@pytest.mark.filterwarnings('ignore::PendingDeprecationWarning')
 def test_g4adaptor_writelat_cb(tmpdir):
     '''
     Code is from demo_lat_callback.py
     '''
-
 
     '''
     Shorter lattice with SASE1-type FODO (uses functionality added by CL to OCELOT in Feb 2024)

--- a/unit_tests/adaptors_test/test_g4adaptor.py
+++ b/unit_tests/adaptors_test/test_g4adaptor.py
@@ -5,8 +5,12 @@ from ocelot.adaptors.genesis4 import *
 from ocelot.gui.beam_plot import *
 from ocelot.utils.xfel_utils import create_fel_beamline
 
+# TODO: Add test for functionality to write user-provided
+# string to lattice file. Can be done once the branches are merged.
+
+# Simple callback function for testing callbacks from 'write_gen4_lat'
 def my_cb_latline(lat, element, eleidx, element_prefix):
-	# put marker for this test
+    # put marker for this test
     element.cb_invoked=True
     
     # standard behavior of G4 adaptor

--- a/unit_tests/adaptors_test/test_g4adaptor.py
+++ b/unit_tests/adaptors_test/test_g4adaptor.py
@@ -1,0 +1,57 @@
+# C. Lechner, European XFEL, 2024-03-24
+
+import ocelot
+from ocelot.adaptors.genesis4 import *
+from ocelot.gui.beam_plot import *
+from ocelot.utils.xfel_utils import create_fel_beamline
+
+def my_cb_latline(lat, element, eleidx, element_prefix):
+	# put marker for this test
+    element.cb_invoked=True
+    
+    # standard behavior of G4 adaptor
+    return (None,None)
+
+
+# Remark: there are 30+ PendingDeprecationWarning messages, related to genesis.py and the use of np.matrix
+def test_g4adaptor_writelat_cb(tmpdir):
+    '''
+    Code is from demo_lat_callback.py
+    '''
+
+
+    '''
+    Shorter lattice with SASE1-type FODO (uses functionality added by CL to OCELOT in Feb 2024)
+    New feature added in March-2024: Request complete final half-cell
+    -> this allows to match two-undulator-cell lattice
+    '''
+    sase_lat_pkg = create_fel_beamline('sase1', override_und_N=2, final_halfcell_complete=True)
+
+    # set up electron optics, undulator aw value
+    betaavg = 20 # m
+    Ephot = 9000 # eV
+    beam = generate_beam(
+        E=14, dE=0.003,
+        I=5000, shape='flattop', l_beam=1e-6, l_window=1.5e-6,
+        emit_n=0.4e-6, beta=betaavg, nslice=2)
+    prepare_el_optics(beam, sase_lat_pkg, E_photon=Ephot, beta_av=betaavg)
+
+    sase_lat, _, _ = sase_lat_pkg
+    sase_lat2 = deepcopy(sase_lat)
+    #print(str(sase_lat))
+
+    # working directory for the test
+    # https://docs.pytest.org/en/6.2.x/tmpdir.html
+    wd = tmpdir
+    import os.path
+
+    ### Write lattices ###
+    # standard lattice
+    write_gen4_lat({'LX':sase_lat,'LY':sase_lat2}, filepath=os.path.abspath(wd.join('./lat_no_cb.lat')))
+    # lattice with callback function in effect, with aw values replaced by references to sequence
+    write_gen4_lat({'LX':sase_lat,'LY':sase_lat2}, filepath=os.path.abspath(wd.join('./lat_with_cb.lat')), cb_latline=my_cb_latline)
+    
+    # Arriving here, we know that function 'write_gen4_lat' accepted the 'cb_latline' argument
+
+    # check for presence of marker put in callback function
+    assert sase_lat.sequence[0].cb_invoked==True


### PR DESCRIPTION
Description:
* Implements tests for callback functionality recently added to write_gen4_lat function in adaptor for GENESIS 1.3, v4.
* Disabled broken test function `test_beam_transform` in adaptor for GENESIS 1.3, v2 (file `ocelot/adaptors/genesis.py`).

Note that currently the test triggers about 30 warnings of type PendingDeprecationWarning resulting from use of the deprecated numpy.matrix in the `genesis.py`. To fix these, changes to genesis.py will be needed.