### PR TITLE
Enable OCELOT's type hints for downstream packages that use OCELOT

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
         'numpy', 'scipy', 'matplotlib', 'pandas', 'h5py'
     ],
     extras_require={'docs': ['Sphinx', 'alabaster', 'sphinxcontrib-jsmath']},
-    package_data={'ocelot.optics': ['data/*.dat']},
+    package_data={'ocelot.optics': ['data/*.dat'],
+                  "ocelot": ["py.typed"]},
     license="GNU General Public License v3.0",
 )


### PR DESCRIPTION
dependent packages can will now be able to use ocelot's type hints

https://peps.python.org/pep-0561/