### PR TITLE
Replace deprecated functions in scipy v1.14.0

### DIFF
--- a/ocelot/common/math_op.py
+++ b/ocelot/common/math_op.py
@@ -2,11 +2,11 @@
 statistical analysis functions, fitting, optimization and the like
 """
 
-import numpy as np
-from scipy.special import gammaincc, gamma, exp1
-from scipy import fftpack, integrate, interpolate
-from scipy import optimize
 import sys
+
+import numpy as np
+from scipy import fftpack, integrate, interpolate, optimize
+from scipy.special import exp1, gamma, gammaincc
 
 try:
     import numba as nb
@@ -69,7 +69,7 @@ def invert_cdf(y, x):
     :return: function
     """
 
-    cum_int = integrate.cumtrapz(y, x, initial=0)
+    cum_int = integrate.cumulative_trapezoid(y, x, initial=0)
     #print("invert", np.max(cum_int), np.min(cum_int))
     cdf = cum_int / (np.max(cum_int) - np.min(cum_int))
     inv_cdf = interpolate.interp1d(cdf, x)

--- a/ocelot/cpbd/beam_params.py
+++ b/ocelot/cpbd/beam_params.py
@@ -66,11 +66,11 @@ def radiation_integrals(lattice, twiss_0, nsuperperiod=1):
                 #H = array(h)
                 H2 = h*h
                 H3 = np.abs(h*h*h)
-                I1 += h*simpson(np.array(Dx), Z)
-                I2 += H2*elem.l  # simpson(H2, Z)*nsuperperiod
-                I3 += H3*elem.l  # simpson(H3, Z)*nsuperperiod
-                I4 += h*(2*elem.k1 + H2)*simpson(np.array(Dx), Z)
-                I5 += H3*simpson(np.array(Hinvariant), Z)
+                I1 += h*simpson(np.array(Dx), x=Z)
+                I2 += H2*elem.l  # simpson(H2, x=Z)*nsuperperiod
+                I3 += H3*elem.l  # simpson(H3, x=Z)*nsuperperiod
+                I4 += h*(2*elem.k1 + H2)*simpson(np.array(Dx), x=Z)
+                I5 += H3*simpson(np.array(Hinvariant), x=Z)
             tws_elem = tm * tws_elem
     # if abs(tws_elem.beta_x - twiss_0.beta_x)>1e-7 or abs(tws_elem.beta_y - twiss_0.beta_y)>1e-7:
     #    print( "WARNING! Results may be wrong! radiation_integral() -> beta functions are not matching. ")

--- a/ocelot/cpbd/beam_params.py
+++ b/ocelot/cpbd/beam_params.py
@@ -1,13 +1,13 @@
 __author__ = 'Sergey'
 
-from scipy.integrate import simps
+from scipy.integrate import simpson
 
-from ocelot.cpbd.optics import trace_z, twiss
+from ocelot.common.ocelog import *
 from ocelot.cpbd.beam import *
 from ocelot.cpbd.elements import *
-from ocelot.rad.undulator_params import *
-from ocelot.common.ocelog import *
+from ocelot.cpbd.optics import trace_z, twiss
 from ocelot.cpbd.transformations.transformation import TMTypes
+from ocelot.rad.undulator_params import *
 
 _logger = logging.getLogger(__name__)
 
@@ -66,11 +66,11 @@ def radiation_integrals(lattice, twiss_0, nsuperperiod=1):
                 #H = array(h)
                 H2 = h*h
                 H3 = np.abs(h*h*h)
-                I1 += h*simps(np.array(Dx), Z)
-                I2 += H2*elem.l  # simps(H2, Z)*nsuperperiod
-                I3 += H3*elem.l  # simps(H3, Z)*nsuperperiod
-                I4 += h*(2*elem.k1 + H2)*simps(np.array(Dx), Z)
-                I5 += H3*simps(np.array(Hinvariant), Z)
+                I1 += h*simpson(np.array(Dx), Z)
+                I2 += H2*elem.l  # simpson(H2, Z)*nsuperperiod
+                I3 += H3*elem.l  # simpson(H3, Z)*nsuperperiod
+                I4 += h*(2*elem.k1 + H2)*simpson(np.array(Dx), Z)
+                I5 += H3*simpson(np.array(Hinvariant), Z)
             tws_elem = tm * tws_elem
     # if abs(tws_elem.beta_x - twiss_0.beta_x)>1e-7 or abs(tws_elem.beta_y - twiss_0.beta_y)>1e-7:
     #    print( "WARNING! Results may be wrong! radiation_integral() -> beta functions are not matching. ")

--- a/ocelot/cpbd/chromaticity.py
+++ b/ocelot/cpbd/chromaticity.py
@@ -42,8 +42,8 @@ def natural_chromaticity(lattice, tws_0, nsuperperiod=1):
                 H2 = np.array(h)*np.array(h)
                 X = np.array(bx)*(np.array(k) + H2)
                 Y = -np.array(by)*np.array(k)
-                integr_x += simpson(X, Z)
-                integr_y += simpson(Y, Z)
+                integr_x += simpson(X, x=Z)
+                integr_y += simpson(Y, x=Z)
             elif elem.__class__ == Multipole:
                 twiss_z = tm * tws_elem
                 integr_x += twiss_z.beta_x*elem.kn[1]
@@ -79,8 +79,8 @@ def sextupole_chromaticity(lattice, tws0, nsuperperiod=1):
 
             X = np.array(bx)*np.array(Dx)
             Y = np.array(by)*np.array(Dx)
-            integr_x += simpson(X, Z)*elem.k2
-            integr_y += simpson(Y, Z)*elem.k2
+            integr_x += simpson(X, x=Z)*elem.k2
+            integr_y += simpson(Y, x=Z)*elem.k2
 
         for tm in elem.first_order_tms:
             tws_elem = tm*tws_elem

--- a/ocelot/cpbd/chromaticity.py
+++ b/ocelot/cpbd/chromaticity.py
@@ -1,12 +1,12 @@
 
 __author__ = 'Sergey Tomin'
 
-from scipy.integrate import simps
 from numpy.linalg import eig
+from scipy.integrate import simpson
 
-from ocelot.cpbd.optics import *
 from ocelot.cpbd.beam import *
 from ocelot.cpbd.elements import *
+from ocelot.cpbd.optics import *
 from ocelot.cpbd.transformations.transformation import TMTypes
 
 
@@ -42,8 +42,8 @@ def natural_chromaticity(lattice, tws_0, nsuperperiod=1):
                 H2 = np.array(h)*np.array(h)
                 X = np.array(bx)*(np.array(k) + H2)
                 Y = -np.array(by)*np.array(k)
-                integr_x += simps(X, Z)
-                integr_y += simps(Y, Z)
+                integr_x += simpson(X, Z)
+                integr_y += simpson(Y, Z)
             elif elem.__class__ == Multipole:
                 twiss_z = tm * tws_elem
                 integr_x += twiss_z.beta_x*elem.kn[1]
@@ -79,8 +79,8 @@ def sextupole_chromaticity(lattice, tws0, nsuperperiod=1):
 
             X = np.array(bx)*np.array(Dx)
             Y = np.array(by)*np.array(Dx)
-            integr_x += simps(X, Z)*elem.k2
-            integr_y += simps(Y, Z)*elem.k2
+            integr_x += simpson(X, Z)*elem.k2
+            integr_y += simpson(Y, Z)*elem.k2
 
         for tm in elem.first_order_tms:
             tws_elem = tm*tws_elem

--- a/ocelot/cpbd/csr.py
+++ b/ocelot/cpbd/csr.py
@@ -2,27 +2,26 @@
 @ authors Martin Dohlus DESY, 2015, Sergey Tomin XFEL, 2016
 """
 
-import time
 import copy
 import importlib
 import logging
+import time
 
 import numpy as np
-from scipy.integrate import cumtrapz
+from scipy.integrate import cumulative_trapezoid
 
-from ocelot.common.globals import pi, speed_of_light, m_e_eV, m_e_GeV
 from ocelot.common import math_op
+from ocelot.common.globals import m_e_eV, m_e_GeV, pi, speed_of_light
 from ocelot.cpbd.beam import Particle, s_to_cur
-from ocelot.cpbd.high_order import arcline, rk_track_in_field
-
-from ocelot.cpbd.elements.undulator import Undulator
-from ocelot.cpbd.elements.undulator_atom import und_field
 from ocelot.cpbd.elements.bend import Bend
 from ocelot.cpbd.elements.rbend import RBend
 from ocelot.cpbd.elements.sbend import SBend
+from ocelot.cpbd.elements.undulator import Undulator
+from ocelot.cpbd.elements.undulator_atom import und_field
 from ocelot.cpbd.elements.xyquadruple import XYQuadrupole
-
+from ocelot.cpbd.high_order import arcline, rk_track_in_field
 from ocelot.cpbd.physics_proc import PhysProc
+
 # matplotlib may or may not be on the HPC nodes at DESY.
 #try:
 #    import matplotlib.pyplot as plt
@@ -42,13 +41,11 @@ except:
 
 try:
 
-    from pyfftw.interfaces.numpy_fft import fft
-    from pyfftw.interfaces.numpy_fft import ifft
+    from pyfftw.interfaces.numpy_fft import fft, ifft
 except:
     logger.info("csr.py: module PYFFTW is not installed."
                 " Install it to speed up calculation.")
-    from numpy.fft import ifft
-    from numpy.fft import fft
+    from numpy.fft import fft, ifft
 
 try:
     import numexpr as ne
@@ -525,7 +522,7 @@ class K0_fin_anf:
             a = np.append(0.5 * (K[0:-1] + K[1:]) * np.diff(s), 0.5 * K[-1] * s[-1])
             KS = np.cumsum(a[::-1])[::-1]
             # KS = cumsum_inv_jit(a)
-            # KS = cumtrapz(K[::-1], -s[::-1], initial=0)[::-1] + 0.5*K[-1]*s[-1]
+            # KS = cumulative_trapezoid(K[::-1], -s[::-1], initial=0)[::-1] + 0.5*K[-1]*s[-1]
         else:
             KS = 0.5 * K[-1] * s[-1]
         return w, KS
@@ -584,7 +581,7 @@ class K0_fin_anf:
         if len(K) > 1:
             a = np.append(0.5 * (K[0:-1] + K[1:]) * np.diff(s), 0.5 * K[-1] * s[-1])
             KS = np.cumsum(a[::-1])[::-1]
-            # KS = cumtrapz(K[::-1], -s[::-1], initial=0)[::-1] + 0.5*K[-1]*s[-1]
+            # KS = cumulative_trapezoid(K[::-1], -s[::-1], initial=0)[::-1] + 0.5*K[-1]*s[-1]
         else:
             KS = 0.5 * K[-1] * s[-1]
 
@@ -641,7 +638,7 @@ class K0_fin_anf:
         if len(K) > 1:
             a = np.append(0.5 * (K[0:-1] + K[1:]) * np.diff(s), 0.5 * K[-1] * s[-1])
             KS = np.cumsum(a[::-1])[::-1]
-            # KS = cumtrapz(K[::-1], -s[::-1], initial=0)[::-1] + 0.5*K[-1]*s[-1]
+            # KS = cumulative_trapezoid(K[::-1], -s[::-1], initial=0)[::-1] + 0.5*K[-1]*s[-1]
         else:
             KS = 0.5 * K[-1] * s[-1]
 
@@ -1035,7 +1032,7 @@ class CSR(PhysProc):
                 yp2 = yp * yp
                 zp = np.sqrt(1./(1. + xp2 + yp2))
 
-                s = cumtrapz(np.sqrt(1. + xp2 + yp2), z, initial=0)
+                s = cumulative_trapezoid(np.sqrt(1. + xp2 + yp2), z, initial=0)
                 if elem.__class__ == Undulator:
                     delta_s = s[-1]
 

--- a/ocelot/cpbd/reswake.py
+++ b/ocelot/cpbd/reswake.py
@@ -1,10 +1,12 @@
 """
 writen by I. Zagorodnov, DESY and S.Tomin XFEL, 2015.
 """
-from scipy.integrate import simps
 import numpy as np
-from numpy.fft import fft, irfft, ifft
+from numpy.fft import fft, ifft, irfft
+from scipy.integrate import simpson
+
 from ocelot.common.globals import *
+
 
 def wake2impedance(s, w):
     """
@@ -106,8 +108,8 @@ def LossShape(bunch, wake):
     w = wake[1]
     bi2 = bunch[1]
     s = wake[0]
-    loss = simps(-bi2*w, s)
-    spread = np.sqrt(simps(bi2*(w + loss)**2, s))
+    loss = simpson(-bi2*w, s)
+    spread = np.sqrt(simpson(bi2*(w + loss)**2, s))
     peak = max(abs(w))
     return loss, spread, peak
 
@@ -126,7 +128,7 @@ def pipe_wake(z, current, tube_radius, tube_len, conductivity, tau, roughness, d
     :return:
     """
 
-    Q = simps(current, z)/speed_of_light
+    Q = simpson(current, z)/speed_of_light
     print ("Charge = ", Q*1e12, "pC")
     
     xb = -z[::-1]
@@ -173,8 +175,8 @@ def xfel_pipe_wake(s, current):
 
 
 if __name__ == "__main__":
-    from numpy import loadtxt
     import matplotlib.pyplot as plt
+    from numpy import loadtxt
     tube_radius = 5e-3 #m radius
     tube_len = 1.   #m length
 

--- a/ocelot/cpbd/reswake.py
+++ b/ocelot/cpbd/reswake.py
@@ -108,8 +108,8 @@ def LossShape(bunch, wake):
     w = wake[1]
     bi2 = bunch[1]
     s = wake[0]
-    loss = simpson(-bi2*w, s)
-    spread = np.sqrt(simpson(bi2*(w + loss)**2, s))
+    loss = simpson(-bi2*w, x=s)
+    spread = np.sqrt(simpson(bi2*(w + loss)**2, x=s))
     peak = max(abs(w))
     return loss, spread, peak
 
@@ -128,7 +128,7 @@ def pipe_wake(z, current, tube_radius, tube_len, conductivity, tau, roughness, d
     :return:
     """
 
-    Q = simpson(current, z)/speed_of_light
+    Q = simpson(current, x=z)/speed_of_light
     print ("Charge = ", Q*1e12, "pC")
     
     xb = -z[::-1]

--- a/ocelot/rad/radiation_py.py
+++ b/ocelot/rad/radiation_py.py
@@ -13,18 +13,17 @@ import time
 from math import pi
 
 import numpy as np
-from scipy.integrate import cumtrapz
-from scipy.interpolate import splrep, splev
+from scipy.integrate import cumulative_trapezoid
+from scipy.interpolate import splev, splrep
 
-from ocelot.rad.spline_py import cspline_coef
-from ocelot.common.globals import m_e_GeV, h_eV_s, q_e, speed_of_light, ro_e
-from ocelot.cpbd.elements.undulator_atom import und_field
-from ocelot.cpbd.elements import Undulator
-from ocelot.cpbd.high_order import rk_track_in_field
-from ocelot.cpbd import track
-from ocelot.cpbd.navi import Navigator
-from ocelot.cpbd import beam
 import ocelot.cpbd.magnetic_lattice as mlattice
+from ocelot.common.globals import h_eV_s, m_e_GeV, q_e, ro_e, speed_of_light
+from ocelot.cpbd import beam, track
+from ocelot.cpbd.elements import Undulator
+from ocelot.cpbd.elements.undulator_atom import und_field
+from ocelot.cpbd.high_order import rk_track_in_field
+from ocelot.cpbd.navi import Navigator
+from ocelot.rad.spline_py import cspline_coef
 
 __author__ = 'Sergey Tomin'
 _logger = logging.getLogger(__name__)
@@ -122,7 +121,7 @@ class BeamTraject:
         xp2 = self.xp(n) ** 2
         yp2 = self.yp(n) ** 2
         # zp = np.sqrt(1. / (1. + xp2 + yp2))
-        s = cumtrapz(np.sqrt(1. + xp2 + yp2), self.z(n), initial=0)
+        s = cumulative_trapezoid(np.sqrt(1. + xp2 + yp2), self.z(n), initial=0)
         return s
 
     def p_array_end(self, p_array):

--- a/ocelot/utils/acc_utils.py
+++ b/ocelot/utils/acc_utils.py
@@ -67,7 +67,7 @@ def bunching(p_array, lambda_mod, smooth_sigma=None):
 
     B = s_to_cur(p_array.tau(), sigma=smooth_sigma, q0=np.sum(p_array.q_array), v=speed_of_light)
 
-    b = np.abs(simpson(B[:, 1] / speed_of_light * np.exp(-1j * 2 * np.pi / lambda_mod * B[:, 0]), B[:, 0])) / np.sum(
+    b = np.abs(simpson(B[:, 1] / speed_of_light * np.exp(-1j * 2 * np.pi / lambda_mod * B[:, 0]), x=B[:, 0])) / np.sum(
         p_array.q_array)
     return b
 
@@ -88,7 +88,7 @@ def slice_bunching(tau, charge, lambda_mod, smooth_sigma=None):
 
     B = s_to_cur(tau, sigma=smooth_sigma, q0=charge, v=speed_of_light)
 
-    b = np.abs(simpson(B[:, 1] / speed_of_light * np.exp(-1j * 2 * np.pi / lambda_mod * B[:, 0]), B[:, 0])) / charge
+    b = np.abs(simpson(B[:, 1] / speed_of_light * np.exp(-1j * 2 * np.pi / lambda_mod * B[:, 0]), x=B[:, 0])) / charge
     return b
 
 

--- a/ocelot/utils/acc_utils.py
+++ b/ocelot/utils/acc_utils.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
+
 __author__ = 'Sergey Tomin'
 
-from typing import List, Dict, Type, Callable, Tuple, Union, Any
+from typing import Any, Callable, Dict, List, Tuple, Type, Union
+
 import numpy as np
-from scipy.integrate import simps
-from ocelot.common.globals import speed_of_light, Z0, m_e_GeV
-from ocelot.cpbd.beam import s_to_cur
-from ocelot.cpbd.beam import Twiss, SliceParameters
+from scipy.integrate import simpson
+
+from ocelot.common.globals import Z0, m_e_GeV, speed_of_light
+from ocelot.cpbd.beam import SliceParameters, Twiss, s_to_cur
 
 
 def RTU_56(LB, LD, r, m):
@@ -65,7 +67,7 @@ def bunching(p_array, lambda_mod, smooth_sigma=None):
 
     B = s_to_cur(p_array.tau(), sigma=smooth_sigma, q0=np.sum(p_array.q_array), v=speed_of_light)
 
-    b = np.abs(simps(B[:, 1] / speed_of_light * np.exp(-1j * 2 * np.pi / lambda_mod * B[:, 0]), B[:, 0])) / np.sum(
+    b = np.abs(simpson(B[:, 1] / speed_of_light * np.exp(-1j * 2 * np.pi / lambda_mod * B[:, 0]), B[:, 0])) / np.sum(
         p_array.q_array)
     return b
 
@@ -86,7 +88,7 @@ def slice_bunching(tau, charge, lambda_mod, smooth_sigma=None):
 
     B = s_to_cur(tau, sigma=smooth_sigma, q0=charge, v=speed_of_light)
 
-    b = np.abs(simps(B[:, 1] / speed_of_light * np.exp(-1j * 2 * np.pi / lambda_mod * B[:, 0]), B[:, 0])) / charge
+    b = np.abs(simpson(B[:, 1] / speed_of_light * np.exp(-1j * 2 * np.pi / lambda_mod * B[:, 0]), B[:, 0])) / charge
     return b
 
 


### PR DESCRIPTION
Fixes #255 

Replace the deprecated functions `simps` and `cumtrapz` since the latest scipy v1.14.0 release with `simpson` and `cumulative_trapezoid`