### PR TITLE
Update type hints to use union syntax for None in MagneticLattice class

### DIFF
--- a/ocelot/cpbd/magnetic_lattice.py
+++ b/ocelot/cpbd/magnetic_lattice.py
@@ -197,7 +197,7 @@ class MagneticLattice:
           [Small Useful Features](https://nbviewer.org/github/ocelot-collab/ocelot/blob/dev/demos/ipython_tutorials/small_useful_features.ipynb).
     """
 
-    def __init__(self, sequence, start: E = None, stop: E = None, method=None):
+    def __init__(self, sequence, start: E | None = None, stop: E | None = None, method=None):
         if method is None:
             method = {'global': TransferMap}
         if isinstance(method, dict):
@@ -341,8 +341,8 @@ class MagneticLattice:
         LatticeIO.save_lattice(self, tws0=tws0, file_name=file_name, remove_rep_drifts=remove_rep_drifts,
                                power_supply=power_supply)
 
-    def transfer_maps(self, energy, output_at_each_step: bool = False, start: E = None,
-                      stop: E = None):
+    def transfer_maps(self, energy, output_at_each_step: bool = False, start: E | None = None,
+                      stop: E | None = None):
         """
         Calculates the zero, first- and second-order transfer maps for the lattice.
 
@@ -540,7 +540,7 @@ class MagneticLattice:
         return to_longlist_convention(mid_phys), to_longlist_convention(end_phys)
 
 
-    def print_sequence(self, start: E = None, stop: E = None):
+    def print_sequence(self, start: E | None = None, stop: E | None = None):
         sequence = self.get_sequence_part(start, stop)
         lines = ["{:<17} {:<15} {:<10} {:<10}".format('id', 'length', 'start', 'end') ]
         s = 0.


### PR DESCRIPTION
Get rid of annoying complains because type hints for MagneticLattice not done properly