### PR TITLE
changed matcher result to also check if targets are met

### DIFF
--- a/ocelot/cpbd/matcher.py
+++ b/ocelot/cpbd/matcher.py
@@ -1637,6 +1637,7 @@ class MatchProblem:
         tol: float = 1.0e-8,
         verbose: bool = False,
         restore_if_fail: bool = False,
+        strict_success: bool = True,
     ) -> MatchResult:
         """Run numerical optimization and return the best found solution.
 
@@ -1656,6 +1657,10 @@ class MatchProblem:
             Scalar tolerance forwarded to the underlying SciPy solver.
         restore_if_fail:
             If ``True`` and solve fails, restore initial variable values.
+        strict_success:
+            If ``True`` perform additional checks like checking if all targets
+            are met. Non-strict means that the status of the numerical optimizer
+            is forwarded only.
         """
 
         active_vars = self._active_variables()
@@ -1798,6 +1803,9 @@ class MatchProblem:
         merit_eval, target_reports, objective_reports, _state = self.evaluate()
         if not np.isfinite(merit_eval):
             merit_eval = merit
+
+        if strict_success:
+            success = bool(success and all(report.met for report in target_reports))
 
         if restore_if_fail and not success:
             _apply_x(x_saved)

--- a/ocelot/cpbd/matcher.py
+++ b/ocelot/cpbd/matcher.py
@@ -1694,6 +1694,7 @@ class MatchProblem:
         tol: float = 1.0e-8,
         verbose: bool = False,
         restore_if_fail: bool = False,
+        strict_success: bool = True,
     ) -> MatchResult:
         """Run numerical optimization and return the best found solution.
 
@@ -1713,6 +1714,10 @@ class MatchProblem:
             Scalar tolerance forwarded to the underlying SciPy solver.
         restore_if_fail:
             If ``True`` and solve fails, restore initial variable values.
+        strict_success:
+            If ``True`` perform additional checks like checking if all targets
+            are met. Non-strict means that the status of the numerical optimizer
+            is forwarded only.
         """
 
         active_vars = self._active_variables()
@@ -1855,6 +1860,17 @@ class MatchProblem:
         merit_eval, target_reports, objective_reports, _state = self.evaluate()
         if not np.isfinite(merit_eval):
             merit_eval = merit
+
+        if strict_success:
+            unmet = [report for report in target_reports if not report.met]
+            if success and unmet:
+                success = False
+                message = (
+                    f"Matching failed because some targets were not met:\n - "
+                    f"{'\n - '.join(map(lambda t: f"{t.name}: {repr(t)}", unmet))}"
+                    f"\n"
+                    f"This is a consequence of the strict success requirement. The solver reports:\n{message}"
+                )
 
         if restore_if_fail and not success:
             _apply_x(x_saved)

--- a/ocelot/cpbd/matcher.py
+++ b/ocelot/cpbd/matcher.py
@@ -1865,10 +1865,9 @@ class MatchProblem:
             unmet = [report for report in target_reports if not report.met]
             if success and unmet:
                 success = False
+                unmet_str = "\n - ".join(f"{t.name}: {t!r}" for t in unmet)
                 message = (
-                    f"Matching failed because some targets were not met:\n - "
-                    f"{'\n - '.join(map(lambda t: f"{t.name}: {repr(t)}", unmet))}"
-                    f"\n"
+                    f"Matching failed because some targets were not met:\n - {unmet_str}\n"
                     f"This is a consequence of the strict success requirement. The solver reports:\n{message}"
                 )
 

--- a/unit_tests/ebeam_test/matcher/matcher_test.py
+++ b/unit_tests/ebeam_test/matcher/matcher_test.py
@@ -120,6 +120,37 @@ def test_vary_drift_length_with_finite_limits():
     assert 2.0 <= result.variables["D1_l"] <= 5.0
 
 
+def test_success_requires_all_targets_to_be_met():
+    lat, _start, dvar, end = _simple_drift_lattice(1.0)
+    problem = MatchProblem(lat, _twiss_seed())
+    problem.vary_element(dvar, quantity="l", limits=(0.0, 1.0), name="D1_l")
+    problem.target_twiss(end, "s", value=2.0, weight=1.0e6, tol=0.0)
+
+    result = problem.solve(solver="ls_trf", max_iter=80, tol=1.0e-10)
+
+    assert result.optimize_result.success
+    assert not result.success
+    assert not result.target_reports[0].met
+
+
+def test_non_strict_success_uses_optimizer_status():
+    lat, _start, dvar, end = _simple_drift_lattice(1.0)
+    problem = MatchProblem(lat, _twiss_seed())
+    problem.vary_element(dvar, quantity="l", limits=(0.0, 1.0), name="D1_l")
+    problem.target_twiss(end, "s", value=2.0, weight=1.0e6, tol=0.0)
+
+    result = problem.solve(
+        solver="ls_trf",
+        max_iter=80,
+        tol=1.0e-10,
+        strict_success=False,
+    )
+
+    assert result.optimize_result.success
+    assert result.success
+    assert not result.target_reports[0].met
+
+
 def test_vary_bend_angle_with_limits():
     start = Marker(eid="START")
     bvar = Bend(l=1.0, angle=0.20, eid="BVAR")

--- a/unit_tests/ebeam_test/matcher/matcher_test.py
+++ b/unit_tests/ebeam_test/matcher/matcher_test.py
@@ -150,6 +150,37 @@ def test_vary_drift_length_with_finite_limits():
     assert 2.0 <= result.variables["D1_l"] <= 5.0
 
 
+def test_solve_with_strict_success_requires_all_targets_to_be_met():
+    lat, _start, dvar, end = _simple_drift_lattice(1.0)
+    problem = MatchProblem(lat, _twiss_seed())
+    problem.vary_element(dvar, quantity="l", limits=(0.0, 1.0), name="D1_l")
+    problem.target_twiss(end, "s", value=2.0, weight=1.0e6, tol=0.0)
+
+    result = problem.solve(solver="ls_trf", max_iter=80, tol=1.0e-10)
+
+    assert result.optimize_result.success
+    assert not result.success
+    assert not result.target_reports[0].met
+
+
+def test_solve_with_non_strict_success_forwards_optimizer_status():
+    lat, _start, dvar, end = _simple_drift_lattice(1.0)
+    problem = MatchProblem(lat, _twiss_seed())
+    problem.vary_element(dvar, quantity="l", limits=(0.0, 1.0), name="D1_l")
+    problem.target_twiss(end, "s", value=2.0, weight=1.0e6, tol=0.0)
+
+    result = problem.solve(
+        solver="ls_trf",
+        max_iter=80,
+        tol=1.0e-10,
+        strict_success=False,
+    )
+
+    assert result.optimize_result.success
+    assert result.success
+    assert not result.target_reports[0].met
+
+
 def test_vary_bend_angle_with_limits():
     start = Marker(eid="START")
     bvar = Bend(l=1.0, angle=0.20, eid="BVAR")

--- a/unit_tests/ebeam_test/matcher/matcher_test.py
+++ b/unit_tests/ebeam_test/matcher/matcher_test.py
@@ -161,6 +161,7 @@ def test_solve_with_strict_success_requires_all_targets_to_be_met():
     assert result.optimize_result.success
     assert not result.success
     assert not result.target_reports[0].met
+    assert "END.s" in result.message
 
 
 def test_solve_with_non_strict_success_forwards_optimizer_status():


### PR DESCRIPTION
It is confusing to receive successful matches only to discover that they have unmet targets. If a tolerance is provided it should automatically check.

remarks:
- opt-put via struct_success flag
- objectives have no notion being met and are not included